### PR TITLE
fix: misc config fixes for publishing

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,13 +12,6 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Get GitHub access token
-        id: get_access_token
-        uses: tailor-inc/github-actions/get-ghe-access-token@main
-        with:
-          app-id: ${{ secrets.TAILOR_GITHUB_APP_ID }}
-          app-installation-id: ${{ secrets.TAILOR_GITHUB_APP_INSTALLATION_ID }}
-          app-private-key: ${{ secrets.TAILOR_GITHUB_APP_PRIVATE_KEY }}
       - name: Add labels
         uses: release-drafter/release-drafter@65c5fb495d1e69aa8c08a3317bc44ff8aabe9772 # v5.24.0
         with:
@@ -26,4 +19,4 @@ jobs:
           # See https://github.com/release-drafter/release-drafter/issues/1216#issuecomment-1235291851
           disable-releaser: true
         env:
-          GITHUB_TOKEN: ${{ steps.get_access_token.outputs.access_token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_package_client.yml
+++ b/.github/workflows/release_package_client.yml
@@ -24,5 +24,6 @@ jobs:
       - check-existing-release
       - make-release-if-needed
     uses: ./.github/workflows/publish_npm_package.yml
+    secrets: inherit
     with:
       package_name: client

--- a/.github/workflows/release_package_datagrid.yml
+++ b/.github/workflows/release_package_datagrid.yml
@@ -24,5 +24,6 @@ jobs:
       - check-existing-release
       - make-release-if-needed
     uses: ./.github/workflows/publish_npm_package.yml
+    secrets: inherit
     with:
       package_name: datagrid

--- a/.github/workflows/release_package_design-systems.yml
+++ b/.github/workflows/release_package_design-systems.yml
@@ -25,5 +25,6 @@ jobs:
       - check-existing-release
       - make-release-if-needed
     uses: ./.github/workflows/publish_npm_package.yml
+    secrets: inherit
     with:
       package_name: design-systems

--- a/.github/workflows/release_package_dev-config.yml
+++ b/.github/workflows/release_package_dev-config.yml
@@ -24,5 +24,6 @@ jobs:
       - check-existing-release
       - make-release-if-needed
     uses: ./.github/workflows/publish_npm_package.yml
+    secrets: inherit
     with:
       package_name: dev-config

--- a/.github/workflows/release_package_monitoring.yml
+++ b/.github/workflows/release_package_monitoring.yml
@@ -24,5 +24,6 @@ jobs:
       - check-existing-release
       - make-release-if-needed
     uses: ./.github/workflows/publish_npm_package.yml
+    secrets: inherit
     with:
       package_name: monitoring

--- a/.github/workflows/release_package_oidc-client.yml
+++ b/.github/workflows/release_package_oidc-client.yml
@@ -24,5 +24,6 @@ jobs:
       - check-existing-release
       - make-release-if-needed
     uses: ./.github/workflows/publish_npm_package.yml
+    secrets: inherit
     with:
       package_name: oidc-client

--- a/.github/workflows/release_package_utils.yml
+++ b/.github/workflows/release_package_utils.yml
@@ -24,5 +24,6 @@ jobs:
       - check-existing-release
       - make-release-if-needed
     uses: ./.github/workflows/publish_npm_package.yml
+    secrets: inherit
     with:
       package_name: utils

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend-packages",
+  "name": "@tailor-platform/frontend-packages",
   "private": true,
   "scripts": {
     "build": "find packages -type d -name dist -exec rm -rf {} +; turbo run build",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -15,9 +15,6 @@
   "files": [
     "dist/**"
   ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
-  },
   "repository": "https://github.com/tailor-platform/frontend-packages",
   "scripts": {
     "build": "tsup index.tsx --format cjs,esm --dts --external react",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -20,9 +20,6 @@
   "files": [
     "dist/**"
   ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
-  },
   "repository": "https://github.com/tailor-platform/frontend-packages",
   "scripts": {
     "build": "tsup --entry src/index.tsx --entry src/client.tsx --entry src/theme.tsx --format cjs,esm --dts --external react",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/monitoring",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/oidc-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
# Background

Transitioning from a private GHE repo to a public one: some defects fell through the cracks

# Changes

- bumping some packages: publishing from local without properly preparing the package 🤦  => unpublishing => npmjs forbids republishing with same version (contrary to Github Packages)
- secrets need to be explicitly set as inheritable when reusing workflows. It worked before without this because we relied on the automatically set and accessible `GITHUB_TOKEN` special secret.
- a couple of package.json files had their registry set to Github Packages still 🤦 