### PR TITLE
feat(utils): add legacy utils package 

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/utils",
-  "version": "0.3.0-preview.1",
+  "version": "0.3.0-preview.2",
   "private": false,
   "exports": {
     "./date": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,14 +6,17 @@
     "./date": {
       "types": "./dist/date.d.ts",
       "import": "./dist/date.mjs",
-      "require": "./dist/date.d.js",
-      "module": "./dist/date.js"
+      "default": "./dist/date.js"
     },
     "./time": {
       "types": "./dist/time.d.ts",
       "import": "./dist/time.mjs",
-      "require": "./dist/time.d.js",
-      "module": "./dist/time.js"
+      "default": "./dist/time.js"
+    },
+    "./legacy": {
+      "types": "./dist/legacy.d.ts",
+      "import": "./dist/legacy.mjs",
+      "default": "./dist/legacy.js"
     }
   },
   "files": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,7 +21,7 @@
   ],
   "repository": "https://github.com/tailor-platform/frontend-packages",
   "scripts": {
-    "build": "tsup --entry.date src/date/index.ts --entry.time src/time/index.ts --format cjs,esm --dts",
+    "build": "tsup --entry.date src/date/index.ts --entry.time src/time/index.ts --entry.legacy src/legacy/index.ts --format cjs,esm --dts",
     "dev": "pnpm run build -- --watch",
     "lint": "eslint '**/*.{ts,tsx}' --ignore-pattern 'dist/*' --max-warnings=0",
     "test": "vitest run",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/utils",
-  "version": "0.2.0",
+  "version": "0.3.0-preview.1",
   "private": false,
   "exports": {
     "./date": {

--- a/packages/utils/src/legacy/index.test.ts
+++ b/packages/utils/src/legacy/index.test.ts
@@ -1,0 +1,83 @@
+import { TailorGqlDate, TailorGqlTime } from "../types";
+import {
+  getMinutesFromTailorTime,
+  isTailorDate,
+  isTailorTime,
+  parseDatetime,
+  toDate,
+  toMinFromTailorTime,
+  toTailorDate,
+  toTailorTime,
+} from "./index";
+
+test("isTailorDate", () => {
+  expect(isTailorDate("2020-01-01")).toBeTruthy();
+  expect(isTailorDate("2020-01-01" as TailorGqlDate)).toBeTruthy();
+  expect(isTailorDate(new Date())).toBeFalsy();
+});
+
+test("isTailorTime", () => {
+  expect(isTailorTime("00:00")).toBeTruthy();
+  expect(isTailorTime("00:00" as TailorGqlTime)).toBeTruthy();
+  expect(isTailorTime("0000")).toBeFalsy();
+  expect(isTailorTime(new Date())).toBeFalsy();
+});
+
+test("getMinutesFromTailorTime", () => {
+  expect(getMinutesFromTailorTime("00:00")).toBe(0);
+  expect(getMinutesFromTailorTime("00:01")).toBe(1);
+  expect(getMinutesFromTailorTime("00:12")).toBe(12);
+});
+
+test("toMinFromTailorTime", () => {
+  expect(toMinFromTailorTime("00:00")).toBe(0);
+  expect(toMinFromTailorTime("00:01")).toBe(1);
+  expect(toMinFromTailorTime("01:01")).toBe(61);
+});
+
+test("toTailorTimeFromHourMin", () => {
+  expect(toTailorTime(0, 0)).toBe("00:00");
+  expect(toTailorTime(undefined, undefined)).toBe("00:00");
+  expect(toTailorTime(0, 1)).toBe("00:01");
+  expect(toTailorTime(0, 10)).toBe("00:10");
+  expect(toTailorTime(1, 10)).toBe("01:10");
+});
+
+test("toTailorDate", () => {
+  expect(toTailorDate(new Date("2020-01-01T00:00:00.000Z"))).toBe("2020-01-01");
+});
+
+test("toTailorTime", () => {
+  expect(toTailorTime(new Date(2020, 1, 1, 0, 0, 0))).toBe("00:00");
+  expect(toTailorTime(new Date(2020, 1, 1, 12, 0, 0))).toBe("12:00");
+  expect(toTailorTime(new Date(2020, 1, 1, 1, 23, 0))).toBe("01:23");
+  expect(toTailorTime(new Date(2020, 1, 1, 21, 11, 0))).toBe("21:11");
+});
+
+test("toDateFromTailorDate", () => {
+  expect(toDate("2020-01-01").toISOString()).toBe("2019-12-31T15:00:00.000Z");
+});
+
+test("toDateFromTailorTime", () => {
+  const current = new Date();
+  expect(toDate("00:00").toISOString()).toEqual(
+    new Date(
+      current.getFullYear(),
+      current.getMonth(),
+      current.getDate(),
+      0,
+      0,
+      0,
+    ).toISOString(),
+  );
+});
+
+test("parseDatetime", () => {
+  const d = parseDatetime("2020-01-02T03:04:05.000Z");
+  expect(d.getFullYear()).toBe(2020);
+  expect(d.getMonth() + 1).toBe(1);
+  expect(d.getDate()).toBe(2);
+  expect(d.getHours()).toBe(12);
+  expect(d.getMinutes()).toBe(4);
+  expect(d.getSeconds()).toBe(5);
+});

--- a/packages/utils/src/legacy/index.ts
+++ b/packages/utils/src/legacy/index.ts
@@ -116,3 +116,6 @@ export const lastDayOfMonth = (date: TailorGqlDate): TailorGqlDate => {
     .toString()
     .padStart(2, "0")}` as TailorGqlDate;
 };
+
+export type TailorDate = ReturnType<typeof toTailorDate>;
+export type TailorTime = ReturnType<typeof toTailorTime>;

--- a/packages/utils/src/legacy/index.ts
+++ b/packages/utils/src/legacy/index.ts
@@ -1,0 +1,118 @@
+import { parseISO } from "date-fns";
+import { TailorGqlDate, TailorGqlTime } from "../types";
+
+export const isTailorDate = (obj: unknown) =>
+  typeof obj === "string" && obj.match(/^\d{4}-\d{2}-\d{2}$/);
+
+export const isTailorTime = (obj: unknown) =>
+  typeof obj === "string" && obj.match(/^\d{2}:\d{2}$/);
+
+export const toTailorDate = (date: Date | string): TailorGqlDate => {
+  if (date instanceof Date) {
+    return `${date.getFullYear()}-${(date.getMonth() + 1)
+      .toString()
+      .padStart(2, "0")}-${date
+      .getDate()
+      .toString()
+      .padStart(2, "0")}` as TailorGqlDate;
+  } else if (typeof date === "string") {
+    const yyyymmdd = date.match(/^(\d{4})(\d{2})(\d{2})$/);
+    if (yyyymmdd) {
+      return `${yyyymmdd[1]}-${yyyymmdd[2]}-${yyyymmdd[3]}` as TailorGqlDate;
+    }
+    if (isTailorDate(date)) {
+      return date as TailorGqlDate;
+    }
+  }
+  return "1900-01-01";
+};
+
+export const toTailorTime = (
+  arg1: Date | string | number | undefined,
+  arg2?: number,
+): TailorGqlTime => {
+  if (typeof arg1 === "string") {
+    const hhmm = arg1.match(/^(\d{2})(\d{2})$/);
+    if (hhmm) {
+      return `${hhmm[1]}:${hhmm[2]}` as TailorGqlTime;
+    }
+  } else if (arg1 instanceof Date) {
+    return `${arg1.getHours().toString().padStart(2, "0")}:${arg1
+      .getMinutes()
+      .toString()
+      .padStart(2, "0")}` as TailorGqlTime;
+  } else if (typeof arg1 === "number" && typeof arg2 === "number") {
+    return `${arg1.toString().padStart(2, "0")}:${arg2
+      .toString()
+      .padStart(2, "0")}` as TailorGqlTime;
+  } else if (typeof arg1 === "number") {
+    const hour = Math.floor(arg1 / 60);
+    const minute = arg1 % 60;
+    return `${hour.toString().padStart(2, "0")}:${minute
+      .toString()
+      .padStart(2, "0")}` as TailorGqlTime;
+  }
+  return "00:00";
+};
+
+export const toMinFromTailorTime = (time: TailorGqlTime): number => {
+  if (!isTailorTime(time)) return 0;
+  const [hour, minute] = time.split(":").map((n) => parseInt(n));
+  return hour * 60 + minute;
+};
+
+export const getMinutesFromTailorTime = (time: TailorGqlTime): number => {
+  if (!isTailorTime(time)) return 0;
+  const [, minute] = time.split(":").map((n) => parseInt(n));
+  return minute;
+};
+
+export const getHoursFromTailorTime = (time: TailorGqlTime): number => {
+  if (!isTailorTime(time)) return 0;
+  const [hour] = time.split(":").map((n) => parseInt(n));
+  return hour;
+};
+
+export const toDate = (
+  arg1: TailorGqlDate | TailorGqlTime,
+  arg2?: Date | TailorGqlDate,
+): Date => {
+  if (isTailorDate(arg1)) {
+    const [year, month, day] = arg1.split("-").map((n) => parseInt(n));
+    return new Date(year, month - 1, day, 0, 0, 0);
+  } else if (isTailorTime(arg1) && isTailorDate(arg2)) {
+    return toDateFromTailorTime(arg1 as TailorGqlTime, arg2 as TailorGqlDate);
+  } else if (isTailorTime(arg1) && arg2 instanceof Date) {
+    return toDateFromTailorTime(arg1 as TailorGqlTime, arg2);
+  } else if (isTailorTime(arg1) && arg2 === undefined) {
+    return toDateFromTailorTime(arg1 as TailorGqlTime, new Date());
+  }
+  return new Date();
+};
+
+const toDateFromTailorTime = (
+  time: TailorGqlTime,
+  baseDate: Date | TailorGqlDate,
+): Date => {
+  if (isTailorDate(baseDate)) {
+    baseDate = toDate(baseDate as TailorGqlDate);
+  }
+  const bd = baseDate as Date;
+  const [hour, minute] = time.split(":").map((n) => parseInt(n));
+  return new Date(bd.getFullYear(), bd.getMonth(), bd.getDate(), hour, minute);
+};
+
+export const parseDatetime = (date: string): Date => parseISO(date);
+
+export const firstDayOfMonth = (date: TailorGqlDate): TailorGqlDate => {
+  const [year, month] = date.split("-").map((n) => parseInt(n));
+  return `${year}-${month.toString().padStart(2, "0")}-01` as TailorGqlDate;
+};
+
+export const lastDayOfMonth = (date: TailorGqlDate): TailorGqlDate => {
+  const [year, month] = date.split("-").map((n) => parseInt(n));
+  const lastDate = new Date(year, month, 0).getDate();
+  return `${year}-${month.toString().padStart(2, "0")}-${lastDate
+    .toString()
+    .padStart(2, "0")}` as TailorGqlDate;
+};


### PR DESCRIPTION
# Background

I found that the change made in https://github.com/tailor-inc/tailor-packages/pull/145 have broken the backward compatibility that SDX apps currently need.

# Changes

This is the PR to revive the old utils functions for backward compatibility. 

I name the package as `legacy` so once migration on SDX apps is done I am going to remove the pacakge.
