### PR TITLE
Use bundler as module resolution mode for Next.js apps

### DIFF
--- a/packages/dev-config/eslint/eslintrc.js
+++ b/packages/dev-config/eslint/eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     ".eslintrc.js",
     "package.json",
     "tsconfig.json",
-    "*.generated.ts",
+    "tsconfig.tsbuildinfo",
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {

--- a/packages/dev-config/package.json
+++ b/packages/dev-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tailor-platform/dev-config",
   "description": "Common package that hosts the rules for ESLint, Prettier and TypeScript.",
-  "version": "0.5.0-preview.1",
+  "version": "0.5.0",
   "private": false,
   "scripts": {
     "build": "exit 0",

--- a/packages/dev-config/package.json
+++ b/packages/dev-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tailor-platform/dev-config",
   "description": "Common package that hosts the rules for ESLint, Prettier and TypeScript.",
-  "version": "0.4.0",
+  "version": "0.5.0-preview.1",
   "private": false,
   "scripts": {
     "build": "exit 0",

--- a/packages/dev-config/typescript/base.json
+++ b/packages/dev-config/typescript/base.json
@@ -15,7 +15,7 @@
     "skipLibCheck": true,
     "strict": true,
     "module": "ESNext",
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Node"
   },
   "exclude": ["node_modules"]
 }

--- a/packages/dev-config/typescript/base.json
+++ b/packages/dev-config/typescript/base.json
@@ -15,7 +15,7 @@
     "skipLibCheck": true,
     "strict": true,
     "module": "ESNext",
-    "moduleResolution": "Node"
+    "moduleResolution": "Bundler"
   },
   "exclude": ["node_modules"]
 }

--- a/packages/dev-config/typescript/nextjs.json
+++ b/packages/dev-config/typescript/nextjs.json
@@ -23,7 +23,8 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "moduleResolution": "Bundler"
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]

--- a/packages/dev-config/typescript/nextjs.json
+++ b/packages/dev-config/typescript/nextjs.json
@@ -23,9 +23,7 @@
       {
         "name": "next"
       }
-    ],
-    "moduleResolution": "NodeNext",
-    "module": "NodeNext"
+    ]
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
# Background

I have set `moduleResolution` as `NodeNext` for Next.js applications in https://github.com/tailor-platform/frontend-packages/pull/9, but found that apollo-client, which is the package we all are using everywhere, is not ESM compatible yet, so setting `NodeNext` prevents us to import apollo-client in apps. Their discussion about ESM support is still on-going so we are not ready to switch into `NodeNext` completely.

https://github.com/apollographql/apollo-feature-requests/issues/287

# Changes

This PR updates tsconfig for Next.js applications to use `bundler` as module resolution mode to keep using apollo-client.

[`"moduleResolution": "bundler"` is a new resolution mode](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#moduleresolution-bundler#moduleresolution-bundler) introduced since TypeScript 5.0.0 beta, and it also provides support of conditional exports while extensionless imports are working fine as well.
