### PR TITLE
fix(oidc-client): fix login navigation not working

### DIFF
--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/oidc-client",
-  "version": "0.4.0",
+  "version": "0.5.0-preview.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/oidc-client",
-  "version": "0.5.0-preview.0",
+  "version": "0.5.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/oidc-client/src/client/hooks.ts
+++ b/packages/oidc-client/src/client/hooks.ts
@@ -15,13 +15,18 @@ export type UserInfo = {
 export const useAuth = () => {
   const config = useTailorAuth();
 
-  const login = (args: { redirectPath: string }): string => {
+  const login = (args: { redirectPath: string }) => {
+    if (window === undefined) {
+      throw new Error("login is only available on client component");
+    }
+
     const apiLoginUrl = config.apiUrl(config.loginPath());
     const callbackPath = config.loginCallbackPath();
     const redirectUrl = encodeURI(
       `${config.appUrl(callbackPath)}?redirect_uri=${args.redirectPath}`,
     );
-    return redirect(`${apiLoginUrl}?redirect_uri=${redirectUrl}`);
+
+    window.location.replace(`${apiLoginUrl}?redirect_uri=${redirectUrl}`);
   };
 
   const refreshToken = async (


### PR DESCRIPTION
# Background

`login` method in `useAuth` hook is not working as expected. 

I have confirmed it was working only in server components, so in IMA I found that it was not working in client components.

# Changes

Just use `window.location.replace` instead of `next/navigation`.
