### PR TITLE
fix(ds): rename color tokens

### DIFF
--- a/apps/storybook/src/stories/composite/Popover.stories.tsx
+++ b/apps/storybook/src/stories/composite/Popover.stories.tsx
@@ -73,7 +73,7 @@ export const Default: Story = {
                     Dismiss
                   </Button>
                 </PopoverCloseTrigger>
-                <Button variant="link" size="sm" color="accent.default">
+                <Button variant="link" size="sm" color="primary.default">
                   Show
                 </Button>
               </Stack>

--- a/packages/datagrid/src/SearchFilter/CustomFilter.tsx
+++ b/packages/datagrid/src/SearchFilter/CustomFilter.tsx
@@ -260,7 +260,7 @@ export const CustomFilter = <TData extends Record<string, unknown>>(
         })}
       </Box>
       <Button
-        backgroundColor="accent.default"
+        backgroundColor="primary.default"
         marginTop={4}
         onClick={() => {
           addNewFilterRowHandler(numberOfFilterRows);

--- a/packages/design-systems/src/theme/recipes/button.ts
+++ b/packages/design-systems/src/theme/recipes/button.ts
@@ -40,7 +40,7 @@ export const button = defineRecipe({
     variant: {
       primary: {
         color: "white",
-        backgroundColor: "accent.default",
+        backgroundColor: "primary.default",
         _disabled: {
           background: "bg.muted",
           color: "fg.placeholder",
@@ -51,7 +51,7 @@ export const button = defineRecipe({
           },
         },
         _hover: {
-          backgroundColor: "accent.emphasized",
+          backgroundColor: "primary.emphasized",
         },
         _focusVisible: {
           zIndex: 1,

--- a/packages/design-systems/src/theme/recipes/checkbox.ts
+++ b/packages/design-systems/src/theme/recipes/checkbox.ts
@@ -41,18 +41,18 @@ export const checkbox = defineRecipe({
         },
       },
       _checked: {
-        background: "accent.default",
-        borderColor: "accent.default",
+        background: "primary.default",
+        borderColor: "primary.default",
         color: "bg.default",
         _hover: {
-          borderColor: "accent.default",
+          borderColor: "primary.default",
         },
       },
       _indeterminate: {
-        borderColor: "accent.default",
-        color: "accent.default",
+        borderColor: "primary.default",
+        color: "primary.default",
         _hover: {
-          borderColor: "accent.default",
+          borderColor: "primary.default",
         },
       },
     },

--- a/packages/design-systems/src/theme/recipes/input.ts
+++ b/packages/design-systems/src/theme/recipes/input.ts
@@ -36,7 +36,7 @@ export const input = defineRecipe({
             _dark: "colors.blue.400",
           },
           boxShadow: "0 0 0 1px var(--shadow)",
-          borderColor: "accent.default",
+          borderColor: "primary.default",
         },
       },
     },

--- a/packages/design-systems/src/theme/recipes/link.ts
+++ b/packages/design-systems/src/theme/recipes/link.ts
@@ -27,11 +27,11 @@ export const link = defineRecipe({
         pl: "4",
         fontSize: { base: "md", lg: "sm" },
         lineHeight: "1.5rem",
-        _hover: { color: "fg.default", borderLeftColor: "accent.muted" },
+        _hover: { color: "fg.default", borderLeftColor: "primary.muted" },
         _currentPage: {
           color: "fg.default",
           fontWeight: "semibold",
-          borderColor: "accent.muted",
+          borderColor: "primary.muted",
         },
       },
       toc: {
@@ -45,14 +45,14 @@ export const link = defineRecipe({
         _currentPage: {
           color: "fg.default",
           fontWeight: "semibold",
-          borderColor: "accent.default",
+          borderColor: "primary.default",
         },
       },
       mdx: {
         color: "fg.emphasized",
         _visited: { color: "fg.emphasized" },
         textDecoration: "underline",
-        textDecorationColor: "accent.muted",
+        textDecorationColor: "primary.muted",
         textUnderlineOffset: "0.2em",
       },
     },

--- a/packages/design-systems/src/theme/recipes/number-input.ts
+++ b/packages/design-systems/src/theme/recipes/number-input.ts
@@ -74,7 +74,7 @@ export const numberInput = defineRecipe({
           _dark: "colors.blue.400",
         },
         boxShadow: "0 0 0 1px var(--shadow)",
-        borderColor: "accent.default",
+        borderColor: "primary.default",
       },
     },
     control: {

--- a/packages/design-systems/src/theme/recipes/radio.ts
+++ b/packages/design-systems/src/theme/recipes/radio.ts
@@ -37,8 +37,8 @@ export const radio = defineRecipe({
         },
       },
       _checked: {
-        background: "accent.default",
-        borderColor: "accent.default",
+        background: "primary.default",
+        borderColor: "primary.default",
         "--outline-color": {
           base: "colors.white",
           _dark: "colors.gray.950",

--- a/packages/design-systems/src/theme/recipes/switch.ts
+++ b/packages/design-systems/src/theme/recipes/switch.ts
@@ -39,7 +39,7 @@ export const switchRecipe = defineRecipe({
         _dark: "brown.900",
       },
       _checked: {
-        background: "accent.default !important",
+        background: "primary.default !important",
       },
       _focusVisible: {
         "--shadow": {

--- a/packages/design-systems/src/theme/recipes/tabs.ts
+++ b/packages/design-systems/src/theme/recipes/tabs.ts
@@ -29,9 +29,9 @@ export const tabs = defineRecipe({
         color: "fg.emphasized",
       },
       _selected: {
-        color: "accent.default",
+        color: "primary.default",
         _hover: {
-          color: "accent.default",
+          color: "primary.default",
         },
       },
       _disabled: {
@@ -41,7 +41,7 @@ export const tabs = defineRecipe({
     },
     indicator: {
       height: "2px",
-      background: "accent.default",
+      background: "primary.default",
       bottom: "-1px",
     },
     content: {
@@ -78,7 +78,7 @@ export const tabs = defineRecipe({
           },
         },
         indicator: {
-          background: "accent.default",
+          background: "primary.default",
         },
       }),
     },

--- a/packages/design-systems/src/theme/semantic-tokens.ts
+++ b/packages/design-systems/src/theme/semantic-tokens.ts
@@ -66,7 +66,7 @@ export const semanticTokens = defineSemanticTokens({
         },
       },
     },
-    accent: {
+    primary: {
       default: {
         value: {
           base: "{colors.tailor-blue.600}",
@@ -107,7 +107,7 @@ export const semanticTokens = defineSemanticTokens({
         },
       },
       accent: {
-        value: "{colors.accent.default}",
+        value: "{colors.primary.default}",
       },
       disabled: {
         value: {

--- a/packages/design-systems/src/theme/slot-recipes/date-picker.ts
+++ b/packages/design-systems/src/theme/slot-recipes/date-picker.ts
@@ -66,7 +66,7 @@ export const datePicker = defineSlotRecipe({
       _today: {
         _before: {
           content: "'−'",
-          color: "accent.default",
+          color: "primary.default",
           position: "absolute",
           marginTop: "6",
         },
@@ -76,7 +76,7 @@ export const datePicker = defineSlotRecipe({
       },
       _selected: {
         _before: {
-          color: "accent.fg",
+          color: "primary.fg",
         },
       },
     },

--- a/packages/design-systems/src/theme/slot-recipes/radio-group.ts
+++ b/packages/design-systems/src/theme/slot-recipes/radio-group.ts
@@ -24,12 +24,12 @@ export const radioGroup = defineSlotRecipe({
         background: "bg.subtle",
       },
       _checked: {
-        background: "accent.default",
+        background: "primary.default",
         borderColor: "border.accent",
         outlineColor: "bg.default",
         outlineStyle: "solid",
         _hover: {
-          background: "accent.default",
+          background: "primary.default",
         },
       },
       _disabled: {

--- a/packages/design-systems/src/theme/slot-recipes/segment-group.ts
+++ b/packages/design-systems/src/theme/slot-recipes/segment-group.ts
@@ -30,7 +30,7 @@ export const segmentGroup = defineSlotRecipe({
       borderLeftWidth: {
         _vertical: "2px",
       },
-      borderColor: "accent.default",
+      borderColor: "primary.default",
       transform: {
         _horizontal: "translateY(1px)",
         _vertical: "translateX(-1px)",

--- a/packages/design-systems/src/theme/slot-recipes/select.ts
+++ b/packages/design-systems/src/theme/slot-recipes/select.ts
@@ -70,7 +70,7 @@ export const select = defineSlotRecipe({
       textStyle: "sm",
     },
     itemIndicator: {
-      color: "accent.default",
+      color: "primary.default",
     },
     label: {
       color: "fg.default",
@@ -109,7 +109,7 @@ export const select = defineSlotRecipe({
           borderWidth: "1px",
           _focus: {
             borderColor: "border.accent",
-            boxShadow: "accent",
+            boxShadow: "primary",
           },
         },
       },

--- a/packages/design-systems/src/theme/slot-recipes/slider.ts
+++ b/packages/design-systems/src/theme/slot-recipes/slider.ts
@@ -23,7 +23,7 @@ export const slider = defineSlotRecipe({
       flex: "1",
     },
     range: {
-      background: "accent.default",
+      background: "primary.default",
     },
     thumb: {
       background: "bg.default",

--- a/packages/design-systems/src/theme/slot-recipes/tags-input.ts
+++ b/packages/design-systems/src/theme/slot-recipes/tags-input.ts
@@ -24,7 +24,7 @@ export const tagsInput = defineSlotRecipe({
       transitionTimingFunction: "default",
       _focusWithin: {
         borderColor: "border.accent",
-        boxShadow: "accent",
+        boxShadow: "primary",
       },
     },
     input: {
@@ -41,7 +41,7 @@ export const tagsInput = defineSlotRecipe({
       fontWeight: "medium",
       _highlighted: {
         borderColor: "border.accent",
-        boxShadow: "accent",
+        boxShadow: "primary",
       },
       _hidden: {
         display: "none",


### PR DESCRIPTION
# Background

- Due to the stricter constraints on token names by Panda CSS.

# Changes

- Changed the `accent` color token to `primary`.
