### PR TITLE
feat(ds): add Dialog component

### DIFF
--- a/apps/storybook/src/stories/composite/Dialog.stories.tsx
+++ b/apps/storybook/src/stories/composite/Dialog.stories.tsx
@@ -33,7 +33,7 @@ export const Default: Story = {
         <Dialog
           {...props}
           buttonText="Open Dialog"
-          // title="title"
+          title="title"
           description="Dialog Description"
           isOpen={isOpen}
           setIsOpen={setIsOpen}

--- a/apps/storybook/src/stories/composite/Dialog.stories.tsx
+++ b/apps/storybook/src/stories/composite/Dialog.stories.tsx
@@ -1,9 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import {
-  Dialog,
-  DialogProps,
-} from "@tailor-platform/design-systems";
+import { Dialog, DialogProps } from "@tailor-platform/design-systems";
 import { dialogTypes } from "../../ark-types";
 
 const meta = {

--- a/apps/storybook/src/stories/composite/Dialog.stories.tsx
+++ b/apps/storybook/src/stories/composite/Dialog.stories.tsx
@@ -1,10 +1,9 @@
-import { Dialog, type DialogProps, Portal } from "@ark-ui/react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { X as XIcon } from "lucide-react";
 
-import { Button, IconButton } from "@tailor-platform/design-systems";
-import { Stack } from "@tailor-platform/styled-system/jsx";
-import { dialog } from "@tailor-platform/styled-system/recipes";
+import {
+  Dialog,
+  DialogProps,
+} from "@tailor-platform/design-systems";
 import { dialogTypes } from "../../ark-types";
 
 const meta = {
@@ -20,50 +19,14 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const classes = dialog();
-
 export const Default: Story = {
   render: (props) => (
-    <Dialog.Root {...props}>
-      <Dialog.Trigger asChild>
-        <Button variant="secondary">Open dialog</Button>
-      </Dialog.Trigger>
-      <Portal>
-        <Dialog.Backdrop className={classes.backdrop} />
-        <Dialog.Positioner className={classes.positioner}>
-          <Dialog.Content className={classes.content}>
-            <Stack gap="8" p="6">
-              <Stack gap="1">
-                <Dialog.Title className={classes.title}>
-                  Dialog Title
-                </Dialog.Title>
-                <Dialog.Description className={classes.description}>
-                  Dialog Description
-                </Dialog.Description>
-              </Stack>
-              <Stack gap="3" direction="row" width="full">
-                <Dialog.CloseTrigger asChild>
-                  <Button variant="secondary" width="full">
-                    Cancel
-                  </Button>
-                </Dialog.CloseTrigger>
-                <Button width="full">Confirm</Button>
-              </Stack>
-            </Stack>
-            {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-            {/* @ts-ignore */}
-            <Dialog.CloseTrigger position="absolute" top="2" right="2" asChild>
-              <IconButton
-                aria-label="Close Dialog"
-                variant="tertiary"
-                size="sm"
-              >
-                <XIcon />
-              </IconButton>
-            </Dialog.CloseTrigger>
-          </Dialog.Content>
-        </Dialog.Positioner>
-      </Portal>
-    </Dialog.Root>
+    <Dialog
+      {...props}
+      buttonText="Open Dialog"
+      title="title"
+      description="Dialog Description"
+      confirmFunction={() => console.log("confirm")}
+    />
   ),
 };

--- a/apps/storybook/src/stories/composite/Dialog.stories.tsx
+++ b/apps/storybook/src/stories/composite/Dialog.stories.tsx
@@ -19,13 +19,13 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: function Comp(props) {
-    const [open, setOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(false);
     return (
       <>
         <Button
           variant="secondary"
           onClick={() => {
-            setOpen(!open);
+            setIsOpen(true);
           }}
         >
           Open dialog
@@ -35,8 +35,8 @@ export const Default: Story = {
           buttonText="Open Dialog"
           title="title"
           description="Dialog Description"
-          open={open}
-          setOpen={setOpen}
+          isOpen={isOpen}
+          setIsOpen={setIsOpen}
           onConfirm={(control) => {
             control?.close();
           }}

--- a/apps/storybook/src/stories/composite/Dialog.stories.tsx
+++ b/apps/storybook/src/stories/composite/Dialog.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Dialog, DialogProps } from "@tailor-platform/design-systems";
+import { Button, Dialog, DialogProps } from "@tailor-platform/design-systems";
 import { dialogTypes } from "../../ark-types";
+import { useState } from "react";
 
 const meta = {
   title: "Composite/Dialog",
@@ -17,13 +18,30 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: (props) => (
-    <Dialog
-      {...props}
-      buttonText="Open Dialog"
-      title="title"
-      description="Dialog Description"
-      confirmFunction={() => console.log("confirm")}
-    />
-  ),
+  render: (props) => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button
+          variant="secondary"
+          onClick={() => {
+            setOpen(!open);
+          }}
+        >
+          Open dialog
+        </Button>
+        <Dialog
+          {...props}
+          buttonText="Open Dialog"
+          title="title"
+          description="Dialog Description"
+          open={open}
+          setOpen={setOpen}
+          onConfirm={(control) => {
+            control?.close();
+          }}
+        />
+      </>
+    );
+  },
 };

--- a/apps/storybook/src/stories/composite/Dialog.stories.tsx
+++ b/apps/storybook/src/stories/composite/Dialog.stories.tsx
@@ -18,7 +18,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: (props) => {
+  render: function Comp(props) {
     const [open, setOpen] = useState(false);
     return (
       <>

--- a/apps/storybook/src/stories/composite/Dialog.stories.tsx
+++ b/apps/storybook/src/stories/composite/Dialog.stories.tsx
@@ -33,7 +33,7 @@ export const Default: Story = {
         <Dialog
           {...props}
           buttonText="Open Dialog"
-          title="title"
+          // title="title"
           description="Dialog Description"
           isOpen={isOpen}
           setIsOpen={setIsOpen}

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Dialog.tsx
+++ b/packages/design-systems/src/components/composite/Dialog.tsx
@@ -11,14 +11,17 @@ import { X as XIcon } from "lucide-react";
 import { Button } from "../Button";
 import { IconButton } from "../IconButton";
 import { Stack } from "../patterns/Stack";
+import { ReactNode } from "react";
 
 type DialogContentProps = {
   buttonText: string;
   title: string;
-  description: string;
+  description: ReactNode;
   cancelText?: string;
   confirmText?: string;
-  confirmFunction: () => void;
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onConfirm: (control?: { close: () => void }) => void;
 };
 
 export type DialogProps = ArkDialogProps &
@@ -32,16 +35,22 @@ export const Dialog = (props: DialogProps) => {
     description,
     cancelText = "cancel",
     confirmText = "confirm",
-    confirmFunction,
+    open,
+    setOpen,
+    onConfirm,
     ...rest
   } = props;
 
   const classes = dialog();
+  const close = () => setOpen(false);
   return (
-    <ArkDialog.Root {...rest}>
-      <ArkDialog.Trigger asChild>
-        <Button variant="secondary">{buttonText}</Button>
-      </ArkDialog.Trigger>
+    <ArkDialog.Root
+      open={open}
+      onPointerDownOutside={() => {
+        close();
+      }}
+      {...rest}
+    >
       <Portal>
         <ArkDialog.Backdrop className={classes.backdrop} />
         <ArkDialog.Positioner className={classes.positioner}>
@@ -57,11 +66,15 @@ export const Dialog = (props: DialogProps) => {
               </Stack>
               <Stack gap="3" direction="row" width="full">
                 <ArkDialog.CloseTrigger asChild>
-                  <Button variant="secondary" width="full">
+                  <Button
+                    onClick={() => close()}
+                    variant="secondary"
+                    width="full"
+                  >
                     {cancelText}
                   </Button>
                 </ArkDialog.CloseTrigger>
-                <Button onClick={() => confirmFunction()} width="full">
+                <Button onClick={() => onConfirm({ close })} width="full">
                   {confirmText}
                 </Button>
               </Stack>
@@ -78,6 +91,7 @@ export const Dialog = (props: DialogProps) => {
                 aria-label="Close Dialog"
                 variant="tertiary"
                 size="sm"
+                onClick={() => close()}
               >
                 <XIcon />
               </IconButton>

--- a/packages/design-systems/src/components/composite/Dialog.tsx
+++ b/packages/design-systems/src/components/composite/Dialog.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from "react";
 import {
   Dialog as ArkDialog,
   DialogProps as ArkDialogProps,
@@ -11,7 +12,6 @@ import { X as XIcon } from "lucide-react";
 import { Button } from "../Button";
 import { IconButton } from "../IconButton";
 import { Stack } from "../patterns/Stack";
-import { ReactNode } from "react";
 
 type DialogContentProps = {
   buttonText: string;

--- a/packages/design-systems/src/components/composite/Dialog.tsx
+++ b/packages/design-systems/src/components/composite/Dialog.tsx
@@ -7,10 +7,10 @@ import {
   dialog,
   DialogVariantProps,
 } from "@tailor-platform/styled-system/recipes";
+import { X as XIcon } from "lucide-react";
 import { Button } from "../Button";
 import { IconButton } from "../IconButton";
 import { Stack } from "../patterns/Stack";
-import { X as XIcon } from "lucide-react";
 
 type DialogContentProps = {
   buttonText: string;

--- a/packages/design-systems/src/components/composite/Dialog.tsx
+++ b/packages/design-systems/src/components/composite/Dialog.tsx
@@ -1,7 +1,7 @@
 import {
   Dialog as ArkDialog,
   DialogProps as ArkDialogProps,
-  Portal
+  Portal,
 } from "@ark-ui/react";
 import {
   dialog,
@@ -12,15 +12,35 @@ import { IconButton } from "../IconButton";
 import { Stack } from "../patterns/Stack";
 import { X as XIcon } from "lucide-react";
 
+type DialogContentProps = {
+  buttonText: string;
+  title: string;
+  description: string;
+  cancelText?: string;
+  confirmText?: string;
+  confirmFunction: () => void;
+};
 
-export type DialogProps = ArkDialogProps & DialogVariantProps;
+export type DialogProps = ArkDialogProps &
+  DialogVariantProps &
+  DialogContentProps;
 
 export const Dialog = (props: DialogProps) => {
+  const {
+    buttonText,
+    title,
+    description,
+    cancelText = "cancel",
+    confirmText = "confirm",
+    confirmFunction,
+    ...rest
+  } = props;
+
   const classes = dialog();
   return (
-    <ArkDialog.Root {...props}>
+    <ArkDialog.Root {...rest}>
       <ArkDialog.Trigger asChild>
-        <Button variant="secondary">Open dialog</Button>
+        <Button variant="secondary">{buttonText}</Button>
       </ArkDialog.Trigger>
       <Portal>
         <ArkDialog.Backdrop className={classes.backdrop} />
@@ -29,24 +49,26 @@ export const Dialog = (props: DialogProps) => {
             <Stack gap="8" p="6">
               <Stack gap="1">
                 <ArkDialog.Title className={classes.title}>
-                  Dialog Title
+                  {title}
                 </ArkDialog.Title>
                 <ArkDialog.Description className={classes.description}>
-                  Dialog Description
+                  {description}
                 </ArkDialog.Description>
               </Stack>
               <Stack gap="3" direction="row" width="full">
                 <ArkDialog.CloseTrigger asChild>
                   <Button variant="secondary" width="full">
-                    Cancel
+                    {cancelText}
                   </Button>
                 </ArkDialog.CloseTrigger>
-                <Button width="full">Confirm</Button>
+                <Button onClick={() => confirmFunction()} width="full">
+                  {confirmText}
+                </Button>
               </Stack>
             </Stack>
             {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-            {/* @ts-ignore */}
             <ArkDialog.CloseTrigger
+              /* @ts-ignore */
               position="absolute"
               top="2"
               right="2"

--- a/packages/design-systems/src/components/composite/Dialog.tsx
+++ b/packages/design-systems/src/components/composite/Dialog.tsx
@@ -15,12 +15,12 @@ import { Stack } from "../patterns/Stack";
 
 type DialogContentProps = {
   buttonText: string;
-  title: string;
+  title?: string;
   description: ReactNode;
   cancelText?: string;
   confirmText?: string;
   isOpen: boolean;
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsOpen: (isOpen: boolean) => void;
   onConfirm: (control?: { close: () => void }) => void;
 };
 
@@ -33,8 +33,8 @@ export const Dialog = (props: DialogProps) => {
     buttonText,
     title,
     description,
-    cancelText = "cancel",
-    confirmText = "confirm",
+    cancelText = "Cancel",
+    confirmText = "Confirm",
     isOpen,
     setIsOpen,
     onConfirm,
@@ -55,9 +55,11 @@ export const Dialog = (props: DialogProps) => {
           <ArkDialog.Content className={classes.content}>
             <Stack gap="8" p="6">
               <Stack gap="1">
-                <ArkDialog.Title className={classes.title}>
-                  {title}
-                </ArkDialog.Title>
+                {title && (
+                  <ArkDialog.Title className={classes.title}>
+                    {title}
+                  </ArkDialog.Title>
+                )}
                 <ArkDialog.Description className={classes.description}>
                   {description}
                 </ArkDialog.Description>

--- a/packages/design-systems/src/components/composite/Dialog.tsx
+++ b/packages/design-systems/src/components/composite/Dialog.tsx
@@ -1,0 +1,70 @@
+import {
+  Dialog as ArkDialog,
+  DialogProps as ArkDialogProps,
+  Portal
+} from "@ark-ui/react";
+import {
+  dialog,
+  DialogVariantProps,
+} from "@tailor-platform/styled-system/recipes";
+import { Button } from "../Button";
+import { IconButton } from "../IconButton";
+import { Stack } from "../patterns/Stack";
+import { X as XIcon } from "lucide-react";
+
+
+export type DialogProps = ArkDialogProps & DialogVariantProps;
+
+export const Dialog = (props: DialogProps) => {
+  const classes = dialog();
+  return (
+    <ArkDialog.Root {...props}>
+      <ArkDialog.Trigger asChild>
+        <Button variant="secondary">Open dialog</Button>
+      </ArkDialog.Trigger>
+      <Portal>
+        <ArkDialog.Backdrop className={classes.backdrop} />
+        <ArkDialog.Positioner className={classes.positioner}>
+          <ArkDialog.Content className={classes.content}>
+            <Stack gap="8" p="6">
+              <Stack gap="1">
+                <ArkDialog.Title className={classes.title}>
+                  Dialog Title
+                </ArkDialog.Title>
+                <ArkDialog.Description className={classes.description}>
+                  Dialog Description
+                </ArkDialog.Description>
+              </Stack>
+              <Stack gap="3" direction="row" width="full">
+                <ArkDialog.CloseTrigger asChild>
+                  <Button variant="secondary" width="full">
+                    Cancel
+                  </Button>
+                </ArkDialog.CloseTrigger>
+                <Button width="full">Confirm</Button>
+              </Stack>
+            </Stack>
+            {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+            {/* @ts-ignore */}
+            <ArkDialog.CloseTrigger
+              position="absolute"
+              top="2"
+              right="2"
+              asChild
+            >
+              <IconButton
+                aria-label="Close Dialog"
+                variant="tertiary"
+                size="sm"
+              >
+                <XIcon />
+              </IconButton>
+            </ArkDialog.CloseTrigger>
+          </ArkDialog.Content>
+        </ArkDialog.Positioner>
+      </Portal>
+    </ArkDialog.Root>
+  );
+};
+
+Dialog.displayName = "Dialog";

--- a/packages/design-systems/src/components/composite/Dialog.tsx
+++ b/packages/design-systems/src/components/composite/Dialog.tsx
@@ -19,8 +19,8 @@ type DialogContentProps = {
   description: ReactNode;
   cancelText?: string;
   confirmText?: string;
-  open: boolean;
-  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   onConfirm: (control?: { close: () => void }) => void;
 };
 
@@ -35,20 +35,18 @@ export const Dialog = (props: DialogProps) => {
     description,
     cancelText = "cancel",
     confirmText = "confirm",
-    open,
-    setOpen,
+    isOpen,
+    setIsOpen,
     onConfirm,
     ...rest
   } = props;
 
   const classes = dialog();
-  const close = () => setOpen(false);
+  const close = () => setIsOpen(false);
   return (
     <ArkDialog.Root
-      open={open}
-      onPointerDownOutside={() => {
-        close();
-      }}
+      open={isOpen}
+      onOpenChange={(e) => setIsOpen(e.open)}
       {...rest}
     >
       <Portal>

--- a/packages/design-systems/src/index.tsx
+++ b/packages/design-systems/src/index.tsx
@@ -67,3 +67,4 @@ export {
   DatePicker,
   type DatePickerProps,
 } from "@/components/composite/DatePicker";
+export { Dialog, type DialogProps } from "@/components/composite/Dialog";


### PR DESCRIPTION
# Background
[Bundle ark-ui](https://tailor.atlassian.net/browse/FL-98)

> Currently, our design-systems are not fully self-contained. Some components for example on Storybook requires us to install ark-ui to use implement components.
>
> From viewpoint of Developer Experience, it’s a bit clumsy that developers manually have to install ark-ui on their own side. It should be more like automated by bundling ark-ui with the specific version in design-systems.

<!-- Why is this change necessary, how it came to be? -->

# Changes
- add dialog component

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
