### PR TITLE
Feature/datagrid slotrecipe

### DIFF
--- a/apps/storybook/panda.config.ts
+++ b/apps/storybook/panda.config.ts
@@ -6,6 +6,7 @@ export default buildPandaConfig(
     include: [
       "./src/stories/**/*.{js,jsx,ts,tsx}",
       "./../../packages/design-systems/src/**/*.{js,jsx,ts,tsx}",
+      "./../../packages/datagrid/src/**/*.{js,jsx,ts,tsx}",
       "./node_modules/@tailor-platform/datagrid/dist/panda.buildinfo.json",
       "./node_modules/@tailor-platform/design-systems/dist/panda.buildinfo.json",
     ],

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
     "paths": {
+      "@tailor-platform/datagrid/*": [
+        "./node_modules/@tailor-platform/datagrid/dist/*",
+      ],
       "@tailor-platform/dev-config/*": [
         "./node_modules/@tailor-platform/dev-config/*",
       ],

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/datagrid",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -21,7 +21,7 @@
   "repository": "https://github.com/tailor-platform/frontend-packages",
   "scripts": {
     "prepare": "panda codegen",
-    "build": "panda ship --outfile dist/panda.buildinfo.json && tsup src/index.tsx --format cjs,esm --dts --external react",
+    "build": "panda ship --outfile dist/panda.buildinfo.json && tsup --entry src/index.tsx --entry src/client.tsx --format cjs,esm --dts --external react",
     "dev": "pnpm build --watch",
     "lint": "eslint '**/*.{ts,tsx}' --ignore-pattern 'dist/*' --max-warnings=0",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/packages/datagrid/panda.config.ts
+++ b/packages/datagrid/panda.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "@pandacss/dev";
 import { recipes } from "../design-systems/src/theme/recipes";
 import { semanticTokens } from "../design-systems/src/theme/semantic-tokens";
 import { slotRecipes } from "../design-systems/src/theme/slot-recipes";
+import { datagrid } from "@theme/slot-recipes/datagrid";
 import { textStyles } from "../design-systems/src/theme/text-styles";
 import { tokens } from "../design-systems/src/theme/tokens";
 import { globalCss } from "../design-systems/src/theme/global-css";
@@ -15,6 +16,7 @@ export default defineConfig({
     "../**/*.{ts,tsx}",
     "../../../node_modules/@tailor-platform/src/**/*/tsx",
     "./node_modules/@tailor-platform/design-systems/dist/panda.buildinfo.json",
+    "./theme/**/*.{ts,tsx}",
   ],
   jsxFramework: "react",
   outdir: "../../../node_modules/@tailor-platform/styled-system",
@@ -23,7 +25,10 @@ export default defineConfig({
     extend: {
       recipes,
       semanticTokens,
-      slotRecipes,
+      slotRecipes: {
+        ...slotRecipes,
+        datagrid,
+      },
       textStyles,
       tokens,
     },

--- a/packages/datagrid/src/Datagrid.tsx
+++ b/packages/datagrid/src/Datagrid.tsx
@@ -17,7 +17,6 @@ import {
   TableRow,
   Text,
 } from "@tailor-platform/design-systems";
-import { css } from "@tailor-platform/styled-system/css";
 
 import { Column, ColumnMetaWithTypeInfo, type DataGridInstance } from "@types";
 import { HideShow } from "./ColumnFeature/HideShow";

--- a/packages/datagrid/src/Datagrid.tsx
+++ b/packages/datagrid/src/Datagrid.tsx
@@ -146,21 +146,6 @@ export const DataGrid = <TData extends Record<string, unknown>>({
                       onMouseDown={header.getResizeHandler()}
                       onTouchStart={header.getResizeHandler()}
                       className={datagridClasses.tableHeadDivider}
-                      // className={css({
-                      //   position: "absolute",
-                      //   top: 0,
-                      //   right: 0,
-                      //   height: "100%",
-                      //   width: "4px",
-                      //   background: "rgba(0, 0, 0, 0.5)",
-                      //   cursor: "col-resize",
-                      //   userSelect: "none",
-                      //   touchAction: "none",
-                      //   opacity: 0, //Hide by default
-                      //   _hover: {
-                      //     opacity: 1, //Show on hover
-                      //   },
-                      // })}
                     ></div>
                   )}
                 </TableHead>

--- a/packages/datagrid/src/Datagrid.tsx
+++ b/packages/datagrid/src/Datagrid.tsx
@@ -6,7 +6,7 @@ import { Pagination } from "@ark-ui/react";
 import { DragEvent, useCallback, useEffect, useState } from "react";
 
 import { HStack, Stack } from "@tailor-platform/styled-system/jsx";
-import { pagination } from "@tailor-platform/styled-system/recipes";
+import { pagination, datagrid } from "@tailor-platform/styled-system/recipes";
 import {
   Button,
   Table,
@@ -26,6 +26,7 @@ import "./index.css";
 import { Localization_EN } from "./locales/en";
 
 const classes = pagination();
+const datagridClasses = datagrid();
 
 export const DataGrid = <TData extends Record<string, unknown>>({
   table,
@@ -113,24 +114,15 @@ export const DataGrid = <TData extends Record<string, unknown>>({
         </HStack>
       )}
 
-      <Table
-        className={css({
-          borderWidth: "0.5px",
-          borderColor: "border.default",
-        })}
-      >
+      <Table className={datagridClasses.table}>
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
+            <TableRow className={datagridClasses.tableRow} key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
                 <TableHead
                   key={header.id}
                   colSpan={header.colSpan}
-                  className={css({
-                    position: "relative",
-                    borderWidth: "0.5px",
-                    borderColor: "border.default",
-                  })}
+                  className={datagridClasses.tableHead}
                   style={{
                     width: header.id === "select" ? "40px" : header.getSize(), //First column with checkboxes
                   }}
@@ -153,21 +145,22 @@ export const DataGrid = <TData extends Record<string, unknown>>({
                     <div
                       onMouseDown={header.getResizeHandler()}
                       onTouchStart={header.getResizeHandler()}
-                      className={css({
-                        position: "absolute",
-                        top: 0,
-                        right: 0,
-                        height: "100%",
-                        width: "4px",
-                        background: "rgba(0, 0, 0, 0.5)",
-                        cursor: "col-resize",
-                        userSelect: "none",
-                        touchAction: "none",
-                        opacity: 0, //Hide by default
-                        _hover: {
-                          opacity: 1, //Show on hover
-                        },
-                      })}
+                      className={datagridClasses.tableHeadDivider}
+                      // className={css({
+                      //   position: "absolute",
+                      //   top: 0,
+                      //   right: 0,
+                      //   height: "100%",
+                      //   width: "4px",
+                      //   background: "rgba(0, 0, 0, 0.5)",
+                      //   cursor: "col-resize",
+                      //   userSelect: "none",
+                      //   touchAction: "none",
+                      //   opacity: 0, //Hide by default
+                      //   _hover: {
+                      //     opacity: 1, //Show on hover
+                      //   },
+                      // })}
                     ></div>
                   )}
                 </TableHead>
@@ -195,16 +188,14 @@ export const DataGrid = <TData extends Record<string, unknown>>({
           {table.getRowModel().rows?.length ? (
             table.getRowModel().rows.map((row) => (
               <TableRow
+                className={datagridClasses.tableRow}
                 key={row.id}
                 data-state={row.getIsSelected() && "selected"}
               >
                 {row.getVisibleCells().map((cell) => (
                   <TableCell
                     key={cell.id}
-                    className={css({
-                      borderWidth: "0.5px",
-                      borderColor: "border.default",
-                    })}
+                    className={datagridClasses.tableData}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>

--- a/packages/datagrid/src/client.tsx
+++ b/packages/datagrid/src/client.tsx
@@ -1,0 +1,12 @@
+export { datagrid } from "@theme/slot-recipes/datagrid";
+
+export { Code, type CodeProps } from "../../design-systems/src/components/Code";
+export { Form } from "../../design-systems/src/components/Form";
+
+export { semanticTokens } from "../../design-systems/src/theme/semantic-tokens";
+export { textStyles } from "../../design-systems/src/theme/text-styles";
+export { tokens } from "../../design-systems/src/theme/tokens";
+export { recipes } from "../../design-systems/src/theme/recipes";
+export { slotRecipes } from "../../design-systems/src/theme/slot-recipes";
+export { globalCss } from "../../design-systems/src/theme/global-css";
+export { conditions } from "../../design-systems/src/theme/conditions";

--- a/packages/datagrid/src/theme/slot-recipes/datagrid.ts
+++ b/packages/datagrid/src/theme/slot-recipes/datagrid.ts
@@ -27,13 +27,10 @@ export const datagrid = defineSlotRecipe({
     },
     tableHeadDivider: {
       position: "absolute",
-      top: "50%",
-      // top: 0,
+      top: 0,
       right: 0,
-      height: "50%",
-      // height: "100%",
-      width: "3px",
-      // width: "4px",
+      height: "100%",
+      width: "4px",
       background: "rgba(0, 0, 0, 0.5)",
       cursor: "col-resize",
       userSelect: "none",
@@ -42,10 +39,6 @@ export const datagrid = defineSlotRecipe({
       _hover: {
         opacity: 1, //Show on hover
       },
-      transform: "translateY(-50%)",
-      // _last: {
-      //     opacity: "0 !important",
-      // }
     },
   },
 });

--- a/packages/datagrid/src/theme/slot-recipes/datagrid.ts
+++ b/packages/datagrid/src/theme/slot-recipes/datagrid.ts
@@ -1,0 +1,8 @@
+import { defineSlotRecipe } from "@pandacss/dev";
+
+export const datagrid = defineSlotRecipe({
+    className: "datagrid",
+    slots:[],
+    description: "An datagrid style",
+    base: {}
+})

--- a/packages/datagrid/src/theme/slot-recipes/datagrid.ts
+++ b/packages/datagrid/src/theme/slot-recipes/datagrid.ts
@@ -1,8 +1,51 @@
 import { defineSlotRecipe } from "@pandacss/dev";
 
 export const datagrid = defineSlotRecipe({
-    className: "datagrid",
-    slots:[],
-    description: "An datagrid style",
-    base: {}
-})
+  className: "datagrid",
+  slots: ["table", "tableRow", "tableHead", "tableData", "tableHeadDivider"],
+  description: "An datagrid style",
+  base: {
+    table: {
+      backgroundColor: "white",
+      width: "100%",
+      borderWidth: "0.5px",
+      borderColor: "border.default",
+    },
+    tableRow: {
+      fontSize: "12px",
+      height: "30px",
+      p: 1,
+    },
+    tableHead: {
+      position: "relative",
+      borderWidth: "0.5px",
+      borderColor: "border.default",
+    },
+    tableData: {
+      borderWidth: "0.5px",
+      borderColor: "border.default",
+    },
+    tableHeadDivider: {
+      position: "absolute",
+      top: "50%",
+      // top: 0,
+      right: 0,
+      height: "50%",
+      // height: "100%",
+      width: "3px",
+      // width: "4px",
+      background: "rgba(0, 0, 0, 0.5)",
+      cursor: "col-resize",
+      userSelect: "none",
+      touchAction: "none",
+      opacity: 0, //Hide by default
+      _hover: {
+        opacity: 1, //Show on hover
+      },
+      transform: "translateY(-50%)",
+      // _last: {
+      //     opacity: "0 !important",
+      // }
+    },
+  },
+});

--- a/packages/datagrid/tsconfig.json
+++ b/packages/datagrid/tsconfig.json
@@ -13,7 +13,6 @@
         "./node_modules/@tailor-platform/styled-system/*",
       ],
       "@tailor-platform/design-systems/*": ["../design-systems/dist/*"],
-      // "@tailor-platform/design-systems": ["../design-systems/dist/*"],
     },
   },
 }

--- a/packages/datagrid/tsconfig.json
+++ b/packages/datagrid/tsconfig.json
@@ -13,6 +13,7 @@
         "./node_modules/@tailor-platform/styled-system/*",
       ],
       "@tailor-platform/design-systems/*": ["../design-systems/dist/*"],
+      // "@tailor-platform/design-systems": ["../design-systems/dist/*"],
     },
   },
 }

--- a/packages/dev-config/pandacss/index.ts
+++ b/packages/dev-config/pandacss/index.ts
@@ -9,6 +9,7 @@ import {
   textStyles,
   tokens,
 } from "@tailor-platform/design-systems/client";
+import { datagrid } from "@tailor-platform/datagrid/client";
 
 export function buildPandaConfig(config: Config): Config {
   const mergedConfig: Config = deepmerge(defaultPandaConfig, config);
@@ -26,7 +27,10 @@ export const defaultPandaConfig = defineConfig({
   theme: {
     extend: {
       recipes,
-      slotRecipes,
+      slotRecipes: {
+        ...slotRecipes,
+        datagrid,
+      },
       semanticTokens,
       textStyles,
       tokens,

--- a/packages/dev-config/tsconfig.json
+++ b/packages/dev-config/tsconfig.json
@@ -4,6 +4,7 @@
       "@tailor-platform/design-systems/client": [
         "../design-systems/dist/client",
       ],
+      "@tailor-platform/datagrid/client": ["../datagrid/dist/client"],
     },
   },
 }


### PR DESCRIPTION
# Background
[FL-119](https://tailor.atlassian.net/browse/FL-119)
In apps in Professional Services, we have been writing CSS for datagrid package, but it should be replaced with PandaCSS slot recipes instead.

<!-- Why is this change necessary, how it came to be? -->

# Changes
- define slotRecipes for Datagrid
- add datagrid slotRecipes into dev-config

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
