### PR TITLE
feat(oidc-client): add custom ApolloLink

### DIFF
--- a/packages/oidc-client/README.md
+++ b/packages/oidc-client/README.md
@@ -176,11 +176,11 @@ This package provides adapters to integrate authentication with third-party pack
 `@tailor-platform/oidc-client/adapters/apollo` is a package with custom ApolloLink that automatically sets tokens in authorization header as a bearer token.
 
 ```ts
-import { from, ApolloClient } from '@apollo/client';
+import { ApolloClient } from '@apollo/client';
 import { authenticatedHttpLink } from "@tailor-platform/oidc-client/adapters/apollo";
 import { config } from "@/libs/authConfig";
 
 const client = new ApolloClient({
-  link: from([authenticatedHttpLink(config)]),
+  link: authenticatedHttpLink(config),
 });
 ```

--- a/packages/oidc-client/README.md
+++ b/packages/oidc-client/README.md
@@ -182,5 +182,6 @@ import { config } from "@/libs/authConfig";
 
 const client = new ApolloClient({
   link: authenticatedHttpLink(config),
+  // ...
 });
 ```

--- a/packages/oidc-client/README.md
+++ b/packages/oidc-client/README.md
@@ -176,12 +176,30 @@ This package provides adapters to integrate authentication with third-party pack
 `@tailor-platform/oidc-client/adapters/apollo` is a package with custom ApolloLink that automatically sets tokens in authorization header as a bearer token.
 
 ```ts
-import { ApolloClient } from "@apollo/client";
+"use client";
+import { ApolloClient, InMemoryCache } from "@apollo/client";
 import { authenticatedHttpLink } from "@tailor-platform/oidc-client/adapters/apollo";
+import { TailorAuthProvider } from "@tailor-platform/oidc-client";
+import dynamic from "next/dynamic";
 import { config } from "@/libs/authConfig";
+
+const ApolloProvider = dynamic(
+  () => import("@apollo/client").then((modules) => modules.ApolloProvider),
+  { ssr: false },
+);
 
 const client = new ApolloClient({
   link: authenticatedHttpLink(config),
-  // ...
+  cache: new InMemoryCache(),
 });
+
+export const Providers = ({ children }: { children: ReactNode }) => {
+  return (
+    <TailorAuthProvider config={config}>
+      <ApolloProvider client={client}>
+        {children}
+      </ApolloProvider>
+    </TailorAuthProvider>
+  );
+};
 ```

--- a/packages/oidc-client/README.md
+++ b/packages/oidc-client/README.md
@@ -12,7 +12,7 @@ Create configuration in somewhere in your app:
 import { Config } from "@tailor-platform/oidc-client";
 
 export const config = new Config({
-  apiHost: "http://ima.mini.tailor.tech:8000",
+  apiHost: "http://yourapp.mini.tailor.tech:8000",
   appHost: "http://localhost:3000",
 });
 ```
@@ -165,4 +165,27 @@ const Page = () => {
 
   return <div>Token: {session.token}</div>;
 };
+```
+
+## Adapters
+
+This package provides adapters to integrate authentication with third-party packages.
+
+### Apollo Client
+
+`@tailor-platform/oidc-client/adapters/apollo` is a package with custom ApolloLink that automatically sets tokens in authorization header as a bearer token.
+
+```ts
+import { authLink } from "@tailor-platform/oidc-client/adapters/apollo"
+import { config } from "@/libs/authConfig";
+
+const client = new ApolloClient({
+  link: from([
+    authLink(config),
+    new HttpLink({
+      credentials: "include",
+      uri: "http://yourapp.mini.tailor.tech:8000/query",
+    }),
+  ]),
+})
 ```

--- a/packages/oidc-client/README.md
+++ b/packages/oidc-client/README.md
@@ -176,16 +176,11 @@ This package provides adapters to integrate authentication with third-party pack
 `@tailor-platform/oidc-client/adapters/apollo` is a package with custom ApolloLink that automatically sets tokens in authorization header as a bearer token.
 
 ```ts
-import { authLink } from "@tailor-platform/oidc-client/adapters/apollo";
+import { from, ApolloClient } from '@apollo/client';
+import { authenticatedHttpLink } from "@tailor-platform/oidc-client/adapters/apollo";
 import { config } from "@/libs/authConfig";
 
 const client = new ApolloClient({
-  link: from([
-    authLink(config),
-    new HttpLink({
-      credentials: "include",
-      uri: "http://yourapp.mini.tailor.tech:8000/query",
-    }),
-  ]),
+  link: from([authenticatedHttpLink(config)]),
 });
 ```

--- a/packages/oidc-client/README.md
+++ b/packages/oidc-client/README.md
@@ -176,7 +176,7 @@ This package provides adapters to integrate authentication with third-party pack
 `@tailor-platform/oidc-client/adapters/apollo` is a package with custom ApolloLink that automatically sets tokens in authorization header as a bearer token.
 
 ```ts
-import { ApolloClient } from '@apollo/client';
+import { ApolloClient } from "@apollo/client";
 import { authenticatedHttpLink } from "@tailor-platform/oidc-client/adapters/apollo";
 import { config } from "@/libs/authConfig";
 

--- a/packages/oidc-client/README.md
+++ b/packages/oidc-client/README.md
@@ -176,7 +176,7 @@ This package provides adapters to integrate authentication with third-party pack
 `@tailor-platform/oidc-client/adapters/apollo` is a package with custom ApolloLink that automatically sets tokens in authorization header as a bearer token.
 
 ```ts
-import { authLink } from "@tailor-platform/oidc-client/adapters/apollo"
+import { authLink } from "@tailor-platform/oidc-client/adapters/apollo";
 import { config } from "@/libs/authConfig";
 
 const client = new ApolloClient({
@@ -187,5 +187,5 @@ const client = new ApolloClient({
       uri: "http://yourapp.mini.tailor.tech:8000/query",
     }),
   ]),
-})
+});
 ```

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/oidc-client",
-  "version": "0.7.0-preview.2",
+  "version": "0.7.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -15,6 +15,11 @@
       "types": "./dist/server/index.d.ts",
       "import": "./dist/server/index.mjs",
       "require": "./dist/server/index.js"
+    },
+    "./adapters/apollo": {
+      "types": "./dist/adapters/apollo/index.d.ts",
+      "import": "./dist/adapters/apollo/index.mjs",
+      "require": "./dist/adapters/apollo/index.js"
     }
   },
   "files": [

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -22,7 +22,7 @@
   ],
   "repository": "https://github.com/tailor-platform/frontend-packages",
   "scripts": {
-    "build": "tsup --entry src/client/index.ts --entry src/server/index.ts --format cjs,esm --dts --external react",
+    "build": "tsup",
     "dev": "pnpm run build -- --watch",
     "lint": "eslint '**/*.{ts,tsx}' --ignore-pattern 'dist/*' --max-warnings=0",
     "test": "vitest run --reporter verbose",
@@ -53,7 +53,8 @@
     "vitest": "^1.0.2"
   },
   "peerDependencies": {
-    "next": "^v14"
+    "next": "^v14",
+    "@apollo/client": "^3"
   },
   "prettier": "@tailor-platform/dev-config/prettier"
 }

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/oidc-client",
-  "version": "0.6.1",
+  "version": "0.7.1-preview.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/oidc-client",
-  "version": "0.7.0-preview.0",
+  "version": "0.7.0-preview.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/oidc-client",
-  "version": "0.7.1-preview.0",
+  "version": "0.7.0-preview.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "next": "^v14",
-    "@apollo/client": "^3"
+    "@apollo/client": "^3.9"
   },
   "prettier": "@tailor-platform/dev-config/prettier"
 }

--- a/packages/oidc-client/package.json
+++ b/packages/oidc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/oidc-client",
-  "version": "0.7.0-preview.1",
+  "version": "0.7.0-preview.2",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/oidc-client/src/adapters/apollo/index.ts
+++ b/packages/oidc-client/src/adapters/apollo/index.ts
@@ -1,0 +1,1 @@
+export { authLink } from "./link";

--- a/packages/oidc-client/src/adapters/apollo/index.ts
+++ b/packages/oidc-client/src/adapters/apollo/index.ts
@@ -1,1 +1,1 @@
-export { authLink } from "./link";
+export { authenticatedHttpLink } from "./link";

--- a/packages/oidc-client/src/adapters/apollo/link.ts
+++ b/packages/oidc-client/src/adapters/apollo/link.ts
@@ -1,12 +1,16 @@
-import { from, ServerError } from "@apollo/client";
+import { from, HttpLink, ServerError } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
 import { onError } from "@apollo/client/link/error";
 import { Config } from "@client";
 import { SessionResult } from "@lib/types";
 import { internalClientSessionPath } from "@server/middleware/internal";
 
-export const authLink = (config: Config) =>
+export const authenticatedHttpLink = (config: Config) =>
   from([
+    new HttpLink({
+      credentials: "include",
+      uri: config.apiUrl("/query"),
+    }),
     setContext(async (_, { headers }) => {
       const buildAuthorizationHeader = async () => {
         if (headers && "authorization" in headers) {

--- a/packages/oidc-client/src/adapters/apollo/link.ts
+++ b/packages/oidc-client/src/adapters/apollo/link.ts
@@ -1,0 +1,52 @@
+import { from, HttpLink, ServerError } from "@apollo/client";
+import { setContext } from "@apollo/client/link/context";
+import { onError } from "@apollo/client/link/error";
+import { Config } from "@client";
+import { SessionResult } from "@lib/types";
+import { internalClientSessionPath } from "@server/middleware/internal";
+
+export const authLink = (config: Config) =>
+  from([
+    new HttpLink({
+      credentials: "include",
+      uri: config.apiUrl("/query"),
+    }),
+    setContext(async (_, { headers }) => {
+      const buildAuthorizationHeader = async () => {
+        if (headers && "authorization" in headers) {
+          // setContext method provides us the context typed as `Record<string, any>` so no way to supress eslint error without disabling it
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+          return { authorization: headers.authorization };
+        }
+
+        const rawResp = await fetch(config.appUrl(internalClientSessionPath));
+        const session = (await rawResp.json()) as SessionResult;
+        if (session.token) {
+          return { authorization: `Bearer ${session.token}` };
+        }
+
+        return {};
+      };
+
+      const authorizationHeaders = await buildAuthorizationHeader();
+      return {
+        // Disabling eslint here by the same reason of L14
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        headers: {
+          ...headers,
+          ...authorizationHeaders,
+        },
+      };
+    }),
+    onError(({ networkError }) => {
+      if (networkError) {
+        if (networkError?.name === "ServerError") {
+          const serverErrorStatusCode = (networkError as ServerError)
+            .statusCode;
+          if (serverErrorStatusCode === 401) {
+            location.replace(config.unauthorizedPath());
+          }
+        }
+      }
+    }),
+  ]);

--- a/packages/oidc-client/src/adapters/apollo/link.ts
+++ b/packages/oidc-client/src/adapters/apollo/link.ts
@@ -7,10 +7,6 @@ import { internalClientSessionPath } from "@server/middleware/internal";
 
 export const authenticatedHttpLink = (config: Config) =>
   from([
-    new HttpLink({
-      credentials: "include",
-      uri: config.apiUrl("/query"),
-    }),
     setContext(async (_, { headers }) => {
       const buildAuthorizationHeader = async () => {
         if (headers && "authorization" in headers) {
@@ -48,5 +44,11 @@ export const authenticatedHttpLink = (config: Config) =>
           }
         }
       }
+    }),
+
+    // HttpLink should always be put at last in order to avoid `You are calling concat on a terminating link` error
+    new HttpLink({
+      credentials: "include",
+      uri: config.apiUrl("/query"),
     }),
   ]);

--- a/packages/oidc-client/src/adapters/apollo/link.ts
+++ b/packages/oidc-client/src/adapters/apollo/link.ts
@@ -35,13 +35,10 @@ export const authenticatedHttpLink = (config: Config) =>
       };
     }),
     onError(({ networkError }) => {
-      if (networkError) {
-        if (networkError?.name === "ServerError") {
-          const serverErrorStatusCode = (networkError as ServerError)
-            .statusCode;
-          if (serverErrorStatusCode === 401) {
-            location.replace(config.unauthorizedPath());
-          }
+      if (networkError?.name === "ServerError") {
+        const serverErrorStatusCode = (networkError as ServerError).statusCode;
+        if (serverErrorStatusCode === 401) {
+          location.replace(config.unauthorizedPath());
         }
       }
     }),

--- a/packages/oidc-client/src/adapters/apollo/link.ts
+++ b/packages/oidc-client/src/adapters/apollo/link.ts
@@ -1,4 +1,4 @@
-import { from, HttpLink, ServerError } from "@apollo/client";
+import { from, ServerError } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
 import { onError } from "@apollo/client/link/error";
 import { Config } from "@client";
@@ -7,10 +7,6 @@ import { internalClientSessionPath } from "@server/middleware/internal";
 
 export const authLink = (config: Config) =>
   from([
-    new HttpLink({
-      credentials: "include",
-      uri: config.apiUrl("/query"),
-    }),
     setContext(async (_, { headers }) => {
       const buildAuthorizationHeader = async () => {
         if (headers && "authorization" in headers) {

--- a/packages/oidc-client/tsup.config.ts
+++ b/packages/oidc-client/tsup.config.ts
@@ -1,0 +1,21 @@
+/// <reference types="node" />
+import { defineConfig } from "tsup";
+
+const devOpts =
+  process.env.NODE_ENV === "development"
+    ? {
+        minify: false,
+        splitting: false,
+        sourcemap: true,
+      }
+    : {};
+
+export default defineConfig({
+  entry: ["src/client/index.ts", "src/server/index.ts", "src/adapters/apollo"],
+  clean: true,
+  minify: true,
+  format: ["cjs", "esm"],
+  dts: true,
+  external: ["react", "@apollo/client"],
+  ...devOpts,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,8 +504,8 @@ importers:
   packages/oidc-client:
     dependencies:
       '@apollo/client':
-        specifier: ^3
-        version: 3.8.8(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^3.9
+        version: 3.9.5(@types/react@18.2.42)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       next:
         specifier: ^v14
         version: 14.1.0(@babel/core@7.23.7)(react-dom@18.2.0)(react@18.2.0)
@@ -643,6 +643,45 @@ packages:
       ts-invariant: 0.10.3
       tslib: 2.6.2
       zen-observable-ts: 1.2.5
+    dev: false
+
+  /@apollo/client@3.9.5(@types/react@18.2.42)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-7y+c8MTPU+hhTwvcGVtMMGIgWduzrvG1mz5yJMRyqYbheBkkky3Lki6ADWVSBXG1lZoOtPYvB2zDgVfKb2HSsw==}
+    peerDependencies:
+      graphql: ^15.0.0 || ^16.0.0
+      graphql-ws: ^5.5.5
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
+    peerDependenciesMeta:
+      graphql-ws:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      subscriptions-transport-ws:
+        optional: true
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
+      '@wry/caches': 1.0.1
+      '@wry/equality': 0.5.7
+      '@wry/trie': 0.5.0
+      graphql: 16.8.1
+      graphql-tag: 2.12.6(graphql@16.8.1)
+      hoist-non-react-statics: 3.3.2
+      optimism: 0.18.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      rehackt: 0.0.5(@types/react@18.2.42)(react@18.2.0)
+      response-iterator: 0.2.6
+      symbol-observable: 4.0.0
+      ts-invariant: 0.10.3
+      tslib: 2.6.2
+      zen-observable-ts: 1.2.5
+    transitivePeerDependencies:
+      - '@types/react'
     dev: false
 
   /@ark-ui/anatomy@1.1.0(@internationalized/date@3.5.1):
@@ -14008,6 +14047,21 @@ packages:
     dependencies:
       jsesc: 0.5.0
     dev: true
+
+  /rehackt@0.0.5(@types/react@18.2.42)(react@18.2.0):
+    resolution: {integrity: sha512-BI1rV+miEkaHj8zd2n+gaMgzu/fKz7BGlb4zZ6HAiY9adDmJMkaDcmuXlJFv0eyKUob+oszs3/2gdnXUrzx2Tg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '*'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@types/react': 18.2.42
+      react: 18.2.0
+    dev: false
 
   /remark-external-links@8.0.0:
     resolution: {integrity: sha512-5vPSX0kHoSsqtdftSHhIYofVINC8qmp0nctkeU9YoJwV3YfiBRiI6cbFRJ0oI/1F9xS+bopXG0m2KS8VFscuKA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,6 +503,9 @@ importers:
 
   packages/oidc-client:
     dependencies:
+      '@apollo/client':
+        specifier: ^3
+        version: 3.8.8(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       next:
         specifier: ^v14
         version: 14.1.0(@babel/core@7.23.7)(react-dom@18.2.0)(react@18.2.0)

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
+  "globalEnv": ["NODE_ENV"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
# Background

Users who use apollo-client have to implement their own custom ApolloLink to set tokens from oidc-client to authroization header, but we can provide it as an adapter for easiness.

# Changes

* Add `authLink` that is a custom ApolloLink that sets tokens in authorization headers
* Add apollo-client as a peer dependency
* Add `tsup.config.ts`
* Updated README for instruction