### PR TITLE
feat(ds): add HoverCard components

### DIFF
--- a/apps/storybook/src/stories/composite/HoverCard.stories.tsx
+++ b/apps/storybook/src/stories/composite/HoverCard.stories.tsx
@@ -4,7 +4,7 @@ import {
   Button,
   Text,
   HoverCard,
-  type HoverCardRootProps,
+  type HoverCardProps,
 } from "@tailor-platform/design-systems";
 import { Stack, styled } from "@tailor-platform/styled-system/jsx";
 import { hoverCardTypes } from "../../ark-types";
@@ -17,7 +17,7 @@ const meta = {
   },
   tags: ["autodocs"],
   argTypes: { ...hoverCardTypes },
-} satisfies Meta<HoverCardRootProps>;
+} satisfies Meta<HoverCardProps>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/storybook/src/stories/composite/HoverCard.stories.tsx
+++ b/apps/storybook/src/stories/composite/HoverCard.stories.tsx
@@ -1,11 +1,19 @@
-import { HoverCard, type HoverCardRootProps, Portal } from "@ark-ui/react";
+// import { HoverCard, type HoverCardRootProps, Portal } from "@ark-ui/react";
+// import { HoverCard, type HoverCardProps, Portal } from "@ark-ui/react";
+import { Portal } from "@ark-ui/react";
 import type { Meta, StoryObj } from "@storybook/react";
-
-import { Avatar, Button, Text } from "@tailor-platform/design-systems";
+import {
+  Avatar,
+  Button,
+  Text,
+  HoverCard,
+  type HoverCardRootProps,
+} from "@tailor-platform/design-systems";
 import { Stack, styled } from "@tailor-platform/styled-system/jsx";
 import { hoverCard } from "@tailor-platform/styled-system/recipes";
 
 import { hoverCardTypes } from "../../ark-types";
+import { useState } from "react";
 
 const meta = {
   title: "Composite/HoverCard",
@@ -21,70 +29,67 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: () => (
-    <HoverCard.Root>
-      <HoverCard.Trigger asChild>
-        <a href="https://www.tailor.tech/" target="_blank" rel="noreferrer">
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <a
+          href="https://www.tailor.tech/"
+          onMouseEnter={() => setOpen(true)}
+          onMouseLeave={() => setOpen(false)}
+          target="_blank"
+          rel="noreferrer"
+        >
           <Avatar
             fallback="TA"
             alt="Tailor Avatar"
             src="https://source.boringavatars.com/beam"
           />
         </a>
-      </HoverCard.Trigger>
-      <Portal>
-        <HoverCard.Positioner className={hoverCard()}>
-          <HoverCard.Content>
-            <HoverCard.Arrow>
-              <HoverCard.ArrowTip />
-            </HoverCard.Arrow>
-            <Stack gap="4">
+        <HoverCard open={open}>
+          <Stack gap="4">
+            <Stack direction="row" justifyContent="space-between" width="full">
+              <Avatar
+                fallback="TA"
+                alt="Tailor Avatar"
+                src="https://source.boringavatars.com/beam"
+              />
+              <Button
+                variant="secondary"
+                size="xs"
+                onClick={() => alert("Follow")}
+              >
+                Follow
+              </Button>
+            </Stack>
+            <Stack gap="2">
+              <Stack gap="1">
+                <Stack direction="row" gap="1">
+                  <styled.span textStyle="sm" fontWeight="semibold">
+                    tailor
+                  </styled.span>
+                  <styled.span textStyle="sm" color="fg.muted">
+                    Tailor Inc
+                  </styled.span>
+                </Stack>
+                <Text textStyle="sm">
+                  Composable Headless ERP to build your tailor-made business
+                  apps
+                </Text>
+              </Stack>
               <Stack
                 direction="row"
-                justifyContent="space-between"
-                width="full"
+                gap="1"
+                alignItems="center"
+                color="fg.muted"
               >
-                <Avatar
-                  fallback="TA"
-                  alt="Tailor Avatar"
-                  src="https://source.boringavatars.com/beam"
-                />
-                <Button
-                  variant="secondary"
-                  size="xs"
-                  onClick={() => alert("Follow")}
-                >
-                  Follow
-                </Button>
-              </Stack>
-              <Stack gap="2">
-                <Stack gap="1">
-                  <Stack direction="row" gap="1">
-                    <styled.span textStyle="sm" fontWeight="semibold">
-                      tailor
-                    </styled.span>
-                    <styled.span textStyle="sm" color="fg.muted">
-                      Tailor Inc
-                    </styled.span>
-                  </Stack>
-                  <Text textStyle="sm">
-                    Composable Headless ERP to build your tailor-made business
-                    apps
-                  </Text>
-                </Stack>
-                <Stack
-                  direction="row"
-                  gap="1"
-                  alignItems="center"
-                  color="fg.muted"
-                >
-                  <Text textStyle="xs">Tokyo, Japan</Text>
-                </Stack>
+                <Text textStyle="xs">Tokyo, Japan</Text>
               </Stack>
             </Stack>
-          </HoverCard.Content>
-        </HoverCard.Positioner>
-      </Portal>
-    </HoverCard.Root>
-  ),
+          </Stack>
+        </HoverCard>
+      </>
+    );
+  },
 };

--- a/apps/storybook/src/stories/composite/HoverCard.stories.tsx
+++ b/apps/storybook/src/stories/composite/HoverCard.stories.tsx
@@ -1,6 +1,3 @@
-// import { HoverCard, type HoverCardRootProps, Portal } from "@ark-ui/react";
-// import { HoverCard, type HoverCardProps, Portal } from "@ark-ui/react";
-import { Portal } from "@ark-ui/react";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   Avatar,
@@ -10,10 +7,7 @@ import {
   type HoverCardRootProps,
 } from "@tailor-platform/design-systems";
 import { Stack, styled } from "@tailor-platform/styled-system/jsx";
-import { hoverCard } from "@tailor-platform/styled-system/recipes";
-
 import { hoverCardTypes } from "../../ark-types";
-import { useState } from "react";
 
 const meta = {
   title: "Composite/HoverCard",
@@ -30,66 +24,53 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => {
-    const [open, setOpen] = useState(false);
+    const Trigger = (
+      <a href="https://www.tailor.tech/" target="_blank" rel="noreferrer">
+        <Avatar
+          fallback="TA"
+          alt="Tailor Avatar"
+          src="https://source.boringavatars.com/beam"
+        />
+      </a>
+    );
 
     return (
-      <>
-        <a
-          href="https://www.tailor.tech/"
-          onMouseEnter={() => setOpen(true)}
-          onMouseLeave={() => setOpen(false)}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <Avatar
-            fallback="TA"
-            alt="Tailor Avatar"
-            src="https://source.boringavatars.com/beam"
-          />
-        </a>
-        <HoverCard open={open}>
-          <Stack gap="4">
-            <Stack direction="row" justifyContent="space-between" width="full">
-              <Avatar
-                fallback="TA"
-                alt="Tailor Avatar"
-                src="https://source.boringavatars.com/beam"
-              />
-              <Button
-                variant="secondary"
-                size="xs"
-                onClick={() => alert("Follow")}
-              >
-                Follow
-              </Button>
+      <HoverCard trigger={Trigger}>
+        <Stack gap="4">
+          <Stack direction="row" justifyContent="space-between" width="full">
+            <Avatar
+              fallback="TA"
+              alt="Tailor Avatar"
+              src="https://source.boringavatars.com/beam"
+            />
+            <Button
+              variant="secondary"
+              size="xs"
+              onClick={() => alert("Follow")}
+            >
+              Follow
+            </Button>
+          </Stack>
+          <Stack gap="2">
+            <Stack gap="1">
+              <Stack direction="row" gap="1">
+                <styled.span textStyle="sm" fontWeight="semibold">
+                  tailor
+                </styled.span>
+                <styled.span textStyle="sm" color="fg.muted">
+                  Tailor Inc
+                </styled.span>
+              </Stack>
+              <Text textStyle="sm">
+                Composable Headless ERP to build your tailor-made business apps
+              </Text>
             </Stack>
-            <Stack gap="2">
-              <Stack gap="1">
-                <Stack direction="row" gap="1">
-                  <styled.span textStyle="sm" fontWeight="semibold">
-                    tailor
-                  </styled.span>
-                  <styled.span textStyle="sm" color="fg.muted">
-                    Tailor Inc
-                  </styled.span>
-                </Stack>
-                <Text textStyle="sm">
-                  Composable Headless ERP to build your tailor-made business
-                  apps
-                </Text>
-              </Stack>
-              <Stack
-                direction="row"
-                gap="1"
-                alignItems="center"
-                color="fg.muted"
-              >
-                <Text textStyle="xs">Tokyo, Japan</Text>
-              </Stack>
+            <Stack direction="row" gap="1" alignItems="center" color="fg.muted">
+              <Text textStyle="xs">Tokyo, Japan</Text>
             </Stack>
           </Stack>
-        </HoverCard>
-      </>
+        </Stack>
+      </HoverCard>
     );
   },
 };

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/HoverCard.tsx
+++ b/packages/design-systems/src/components/composite/HoverCard.tsx
@@ -8,26 +8,19 @@ import {
   type HTMLStyledProps,
 } from "@tailor-platform/styled-system/jsx";
 import { hoverCard } from "@tailor-platform/styled-system/recipes";
-import { Avatar } from "../Avatar";
 
 export type HoverCardProps = HTMLStyledProps<"div"> &
   ArkHoverCardProps &
-  React.PropsWithChildren;
+  React.PropsWithChildren & {
+    trigger: React.ReactNode;
+  };
 
 export const HoverCard = (props: HoverCardProps) => {
-  const { children, ...rest } = props;
+  const { children, trigger, ...rest } = props;
   const classes = hoverCard();
   return (
     <ArkHoverCard.Root {...rest}>
-      <ArkHoverCard.Trigger asChild>
-        <a href="https://www.tailor.tech/" target="_blank" rel="noreferrer">
-          <Avatar
-            fallback="TA"
-            alt="Tailor Avatar"
-            src="https://source.boringavatars.com/beam"
-          />
-        </a>
-      </ArkHoverCard.Trigger>
+      <ArkHoverCard.Trigger asChild>{trigger}</ArkHoverCard.Trigger>
       <Portal>
         <ArkHoverCard.Positioner className={classes.positioner}>
           <ArkHoverCard.Content className={classes.content}>

--- a/packages/design-systems/src/components/composite/HoverCard.tsx
+++ b/packages/design-systems/src/components/composite/HoverCard.tsx
@@ -3,10 +3,7 @@ import {
   type HoverCardProps as ArkHoverCardProps,
   Portal,
 } from "@ark-ui/react";
-import {
-  styled,
-  type HTMLStyledProps,
-} from "@tailor-platform/styled-system/jsx";
+import { type HTMLStyledProps } from "@tailor-platform/styled-system/jsx";
 import { hoverCard } from "@tailor-platform/styled-system/recipes";
 
 export type HoverCardProps = HTMLStyledProps<"div"> &

--- a/packages/design-systems/src/components/composite/HoverCard.tsx
+++ b/packages/design-systems/src/components/composite/HoverCard.tsx
@@ -1,0 +1,91 @@
+import {
+  HoverCard as ArkHoverCard,
+  type HoverCardProps as ArkHoverCardProps,
+  Portal,
+} from "@ark-ui/react";
+import {
+  styled,
+  type HTMLStyledProps,
+} from "@tailor-platform/styled-system/jsx";
+import { hoverCard } from "@tailor-platform/styled-system/recipes";
+import { Avatar } from "../Avatar";
+import { Button } from "../Button";
+import { Text } from "../Text";
+import { Stack } from "../patterns/Stack";
+
+export type HoverCardProps = HTMLStyledProps<"div"> & {
+  children?: React.ReactNode;
+};
+
+export const HoverCard = (props: HoverCardProps) => {
+  const { children } = props;
+  const classes = hoverCard();
+  return (
+    <ArkHoverCard.Root>
+      <ArkHoverCard.Trigger asChild>
+        <a href="https://www.tailor.tech/" target="_blank" rel="noreferrer">
+          <Avatar
+            fallback="TA"
+            alt="Tailor Avatar"
+            src="https://source.boringavatars.com/beam"
+          />
+        </a>
+      </ArkHoverCard.Trigger>
+      <Portal>
+        <ArkHoverCard.Positioner className={classes}>
+          <ArkHoverCard.Content>
+            <ArkHoverCard.Arrow>
+              <ArkHoverCard.ArrowTip />
+            </ArkHoverCard.Arrow>
+            <Stack gap="4">
+              <Stack
+                direction="row"
+                justifyContent="space-between"
+                width="full"
+              >
+                <Avatar
+                  fallback="TA"
+                  alt="Tailor Avatar"
+                  src="https://source.boringavatars.com/beam"
+                />
+                <Button
+                  variant="secondary"
+                  size="xs"
+                  onClick={() => alert("Follow")}
+                >
+                  Follow
+                </Button>
+              </Stack>
+              <Stack gap="2">
+                <Stack gap="1">
+                  <Stack direction="row" gap="1">
+                    <styled.span textStyle="sm" fontWeight="semibold">
+                      tailor
+                    </styled.span>
+                    <styled.span textStyle="sm" color="fg.muted">
+                      Tailor Inc
+                    </styled.span>
+                  </Stack>
+                  <Text textStyle="sm">
+                    Composable Headless ERP to build your tailor-made business
+                    apps
+                  </Text>
+                </Stack>
+                <Stack
+                  direction="row"
+                  gap="1"
+                  alignItems="center"
+                  color="fg.muted"
+                >
+                  <Text textStyle="xs">Tokyo, Japan</Text>
+                </Stack>
+              </Stack>
+            </Stack>
+          </ArkHoverCard.Content>
+        </ArkHoverCard.Positioner>
+      </Portal>
+    </ArkHoverCard.Root>
+  );
+};
+
+HoverCard.displayName = "HoverCard";

--- a/packages/design-systems/src/components/composite/HoverCard.tsx
+++ b/packages/design-systems/src/components/composite/HoverCard.tsx
@@ -9,19 +9,16 @@ import {
 } from "@tailor-platform/styled-system/jsx";
 import { hoverCard } from "@tailor-platform/styled-system/recipes";
 import { Avatar } from "../Avatar";
-import { Button } from "../Button";
-import { Text } from "../Text";
-import { Stack } from "../patterns/Stack";
 
-export type HoverCardProps = HTMLStyledProps<"div"> & {
-  children?: React.ReactNode;
-};
+export type HoverCardProps = HTMLStyledProps<"div"> &
+  ArkHoverCardProps &
+  React.PropsWithChildren;
 
 export const HoverCard = (props: HoverCardProps) => {
-  const { children } = props;
+  const { children, ...rest } = props;
   const classes = hoverCard();
   return (
-    <ArkHoverCard.Root>
+    <ArkHoverCard.Root {...rest}>
       <ArkHoverCard.Trigger asChild>
         <a href="https://www.tailor.tech/" target="_blank" rel="noreferrer">
           <Avatar
@@ -32,55 +29,12 @@ export const HoverCard = (props: HoverCardProps) => {
         </a>
       </ArkHoverCard.Trigger>
       <Portal>
-        <ArkHoverCard.Positioner className={classes}>
-          <ArkHoverCard.Content>
-            <ArkHoverCard.Arrow>
-              <ArkHoverCard.ArrowTip />
+        <ArkHoverCard.Positioner className={classes.positioner}>
+          <ArkHoverCard.Content className={classes.content}>
+            <ArkHoverCard.Arrow className={classes.arrow}>
+              <ArkHoverCard.ArrowTip className={classes.arrowTip} />
             </ArkHoverCard.Arrow>
-            <Stack gap="4">
-              <Stack
-                direction="row"
-                justifyContent="space-between"
-                width="full"
-              >
-                <Avatar
-                  fallback="TA"
-                  alt="Tailor Avatar"
-                  src="https://source.boringavatars.com/beam"
-                />
-                <Button
-                  variant="secondary"
-                  size="xs"
-                  onClick={() => alert("Follow")}
-                >
-                  Follow
-                </Button>
-              </Stack>
-              <Stack gap="2">
-                <Stack gap="1">
-                  <Stack direction="row" gap="1">
-                    <styled.span textStyle="sm" fontWeight="semibold">
-                      tailor
-                    </styled.span>
-                    <styled.span textStyle="sm" color="fg.muted">
-                      Tailor Inc
-                    </styled.span>
-                  </Stack>
-                  <Text textStyle="sm">
-                    Composable Headless ERP to build your tailor-made business
-                    apps
-                  </Text>
-                </Stack>
-                <Stack
-                  direction="row"
-                  gap="1"
-                  alignItems="center"
-                  color="fg.muted"
-                >
-                  <Text textStyle="xs">Tokyo, Japan</Text>
-                </Stack>
-              </Stack>
-            </Stack>
+            {children}
           </ArkHoverCard.Content>
         </ArkHoverCard.Positioner>
       </Portal>

--- a/packages/design-systems/src/components/composite/HoverCard.tsx
+++ b/packages/design-systems/src/components/composite/HoverCard.tsx
@@ -1,6 +1,6 @@
 import {
   HoverCard as ArkHoverCard,
-  type HoverCardProps as ArkHoverCardProps,
+  type HoverCardRootProps as ArkHoverCardProps,
   Portal,
 } from "@ark-ui/react";
 import { type HTMLStyledProps } from "@tailor-platform/styled-system/jsx";

--- a/packages/design-systems/src/index.tsx
+++ b/packages/design-systems/src/index.tsx
@@ -68,3 +68,7 @@ export {
   type DatePickerProps,
 } from "@/components/composite/DatePicker";
 export { Dialog, type DialogProps } from "@/components/composite/Dialog";
+export {
+  HoverCard,
+  type HoverCardProps,
+} from "@/components/composite/HoverCard";

--- a/packages/design-systems/src/theme/recipes/index.ts
+++ b/packages/design-systems/src/theme/recipes/index.ts
@@ -6,7 +6,6 @@ import { button } from "./button";
 import { checkbox } from "./checkbox";
 import { dividerStyle } from "./divider";
 import { drawer } from "./drawer";
-import { hoverCard } from "./hover-card";
 import { input } from "./input";
 import { link } from "./link";
 import { pinInput } from "./pin-input";
@@ -26,7 +25,6 @@ export const recipes = {
   checkbox,
   dividerStyle,
   drawer,
-  hoverCard,
   input,
   link,
   pinInput,

--- a/packages/design-systems/src/theme/slot-recipes/hover-card.ts
+++ b/packages/design-systems/src/theme/slot-recipes/hover-card.ts
@@ -21,7 +21,7 @@ export const hoverCard = defineSlotRecipe({
     },
     arrow: {
       "--arrow-size": "12px",
-      "--arrow-background": "bg.surface",
+      "--arrow-background": "bg.canvas",
     },
     arrowTip: {
       borderColor: "bg.surface",

--- a/packages/design-systems/src/theme/slot-recipes/hover-card.ts
+++ b/packages/design-systems/src/theme/slot-recipes/hover-card.ts
@@ -1,12 +1,11 @@
 import { hoverCardAnatomy } from "@ark-ui/anatomy";
-import { defineParts, defineRecipe } from "@pandacss/dev";
+import { defineSlotRecipe } from "@pandacss/dev";
 
-const parts = defineParts(hoverCardAnatomy.build());
-
-export const hoverCard = defineRecipe({
+export const hoverCard = defineSlotRecipe({
   className: "hoverCard",
   description: "A hover card style",
-  base: parts({
+  slots: hoverCardAnatomy.keys(),
+  base: {
     positioner: {
       background: "bg.canvas",
       borderRadius: "lg",
@@ -29,5 +28,6 @@ export const hoverCard = defineRecipe({
       borderTopWidth: "1px",
       borderLeftWidth: "1px",
     },
-  }),
+    trigger: {},
+  },
 });

--- a/packages/design-systems/src/theme/slot-recipes/hover-card.ts
+++ b/packages/design-systems/src/theme/slot-recipes/hover-card.ts
@@ -28,6 +28,5 @@ export const hoverCard = defineSlotRecipe({
       borderTopWidth: "1px",
       borderLeftWidth: "1px",
     },
-    trigger: {},
   },
 });

--- a/packages/design-systems/src/theme/slot-recipes/index.ts
+++ b/packages/design-systems/src/theme/slot-recipes/index.ts
@@ -3,6 +3,7 @@ import { code } from "./code";
 import { datagrid } from "./datagrid";
 import { datePicker } from "./date-picker";
 import { dialog } from "./dialog";
+import { hoverCard } from "./hover-card";
 import { menu } from "./menu";
 import { numberInput } from "./number-input";
 import { pagination } from "./pagination";
@@ -23,6 +24,7 @@ export const slotRecipes = {
   datagrid,
   datePicker,
   dialog,
+  hoverCard,
   menu,
   numberInput,
   pagination,


### PR DESCRIPTION
# Background
[Bundle ark-ui](https://tailor.atlassian.net/browse/FL-98)

> Currently, our design-systems are not fully self-contained. Some components for example on Storybook requires us to install ark-ui to use implement components.
>
> From viewpoint of Developer Experience, it’s a bit clumsy that developers manually have to install ark-ui on their own side. It should be more like automated by bundling ark-ui with the specific version in design-systems.

<!-- Why is this change necessary, how it came to be? -->

# Changes
- add hover card component

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
