### PR TITLE
chore(github actions): update node version 18 to 20

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -10,8 +10,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        # node-version: "20.10.0"
-        node-version-file: 'package.json'
+        node-version-file: "package.json"
 
     - uses: ./.github/actions/install_and_build
       with:

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: "20"
+        node-version: "20.10.0"
 
     - uses: ./.github/actions/install_and_build
       with:

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -10,7 +10,8 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: "20.10.0"
+        # node-version: "20.10.0"
+        node-version-file: 'package.json'
 
     - uses: ./.github/actions/install_and_build
       with:

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: "18.x"
+        node-version: "20"
 
     - uses: ./.github/actions/install_and_build
       with:

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version-file: "package.json"
+        node-version-file: 'package.json'
 
     - uses: ./.github/actions/install_and_build
       with:

--- a/.github/actions/install_and_build/action.yml
+++ b/.github/actions/install_and_build/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version-file: "package.json"
+        node-version-file: 'package.json'
 
     # update corepack because pnpm delegates some commands to npm behind the scenes and
     # out of date versions of corepack fail with "Usage Error: This project is configured to use pnpm"

--- a/.github/actions/install_and_build/action.yml
+++ b/.github/actions/install_and_build/action.yml
@@ -10,7 +10,8 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: "20.10.0"
+        # node-version: "20.10.0"
+        node-version-file: 'package.json'
 
     # update corepack because pnpm delegates some commands to npm behind the scenes and
     # out of date versions of corepack fail with "Usage Error: This project is configured to use pnpm"

--- a/.github/actions/install_and_build/action.yml
+++ b/.github/actions/install_and_build/action.yml
@@ -10,8 +10,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        # node-version: "20.10.0"
-        node-version-file: 'package.json'
+        node-version-file: "package.json"
 
     # update corepack because pnpm delegates some commands to npm behind the scenes and
     # out of date versions of corepack fail with "Usage Error: This project is configured to use pnpm"

--- a/.github/actions/install_and_build/action.yml
+++ b/.github/actions/install_and_build/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: "18.x"
+        node-version: "20"
 
     # update corepack because pnpm delegates some commands to npm behind the scenes and
     # out of date versions of corepack fail with "Usage Error: This project is configured to use pnpm"

--- a/.github/actions/install_and_build/action.yml
+++ b/.github/actions/install_and_build/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |-
         npm i -g npm
-        npm i -g corepack
+        npm i -g corepack@0.25.1
 
     - name: setup pnpm
       shell: bash

--- a/.github/actions/install_and_build/action.yml
+++ b/.github/actions/install_and_build/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |-
         npm i -g npm
-        npm i -g corepack@0.25.1
+        npm i -g corepack@0.24.1
 
     - name: setup pnpm
       shell: bash

--- a/.github/actions/install_and_build/action.yml
+++ b/.github/actions/install_and_build/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: "20"
+        node-version: "20.10.0"
 
     # update corepack because pnpm delegates some commands to npm behind the scenes and
     # out of date versions of corepack fail with "Usage Error: This project is configured to use pnpm"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version-file: "package.json"
+          node-version-file: 'package.json'
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "20"
+          node-version: "20.10.0"
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,8 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          # node-version: "20.10.0"
-          node-version-file: 'package.json'
+          node-version-file: "package.json"
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "20"
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,8 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "20.10.0"
+          # node-version: "20.10.0"
+          node-version-file: 'package.json'
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -16,7 +16,7 @@ jobs:
           clean: true
       - uses: actions/setup-node@v3
         with:
-          node-version: "20"
+          node-version: "20.10.0"
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -16,7 +16,7 @@ jobs:
           clean: true
       - uses: actions/setup-node@v3
         with:
-          node-version-file: "package.json"
+          node-version-file: 'package.json'
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -16,8 +16,7 @@ jobs:
           clean: true
       - uses: actions/setup-node@v3
         with:
-          # node-version: "20.10.0"
-          node-version-file: 'package.json'
+          node-version-file: "package.json"
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -16,7 +16,7 @@ jobs:
           clean: true
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: "20"
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -16,7 +16,8 @@ jobs:
           clean: true
       - uses: actions/setup-node@v3
         with:
-          node-version: "20.10.0"
+          # node-version: "20.10.0"
+          node-version-file: 'package.json'
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/publish_npm_package.yml
+++ b/.github/workflows/publish_npm_package.yml
@@ -20,8 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          # node-version: "20.10.0"
-          node-version-file: 'package.json'
+          node-version-file: "package.json"
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/publish_npm_package.yml
+++ b/.github/workflows/publish_npm_package.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '20'
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/publish_npm_package.yml
+++ b/.github/workflows/publish_npm_package.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version-file: "package.json"
+          node-version-file: 'package.json'
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/publish_npm_package.yml
+++ b/.github/workflows/publish_npm_package.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: "20.10.0"
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/.github/workflows/publish_npm_package.yml
+++ b/.github/workflows/publish_npm_package.yml
@@ -20,7 +20,8 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "20.10.0"
+          # node-version: "20.10.0"
+          node-version-file: 'package.json'
 
       - uses: ./.github/actions/install_and_build
         with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tailor-platform/frontend-packages",
   "private": true,
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "build": "find packages -type d -name dist -exec rm -rf {} +; turbo run build",
     "dev": "turbo run dev",


### PR DESCRIPTION
# Background

github actions  is failing due to the Node version

<img width="1429" alt="スクリーンショット 2024-02-20 18 37 43" src="https://github.com/tailor-platform/frontend-packages/assets/127581494/4112672e-0c28-4be3-abed-6bc223cb6347">


<!-- Why is this change necessary, how it came to be? -->

# Changes

upgrade node version 20

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
