### PR TITLE
feat(auth): add minitailor authentication strategy

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -18,7 +18,6 @@ This package provides ways to handle Tailor authentication
 - [Strategies](#strategies)
   - [Customization](#customization)
 
-
 ## Configuration
 
 Create configuration in somewhere in your app:

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -133,21 +133,19 @@ const Component = async () => {
       // * oidc (default)
       // * saml
       // * minitailor
-      name: "oidc"
+      name: "oidc",
 
       // options are parameters required in strategies specified in `name` field above.
       // the fields here will vary on the strategy you use.
       options: {
         redirectPath: "/dashboard",
-      }
+      },
     });
-  }, [login])
+  }, [login]);
 
   return (
     <div>
-      <button onClick={doLogin}>
-        Login
-      </button>
+      <button onClick={doLogin}>Login</button>
     </div>
   );
 };

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,10 +1,25 @@
-# @tailor-platform/auth
+# @tailor-platform/auth <!-- omit in toc -->
 
 This package provides ways to handle Tailor authentication
 
-## Usage
+- [Configuration](#configuration)
+- [Provider](#provider)
+- [Middlewares](#middlewares)
+  - [`withAuth` middleware for Next.js](#withauth-middleware-for-nextjs)
+- [Hooks (client)](#hooks-client)
+  - [`useSession` hook](#usesession-hook)
+  - [`useAuth` hook](#useauth-hook)
+    - [Login](#login)
+  - [`usePlatform` hook](#useplatform-hook)
+- [Function (server)](#function-server)
+  - [`getServerSession` hook](#getserversession-hook)
+- [Adapters](#adapters)
+  - [Apollo Client](#apollo-client)
+- [Strategies](#strategies)
+  - [Customization](#customization)
 
-### Configuration
+
+## Configuration
 
 Create configuration in somewhere in your app:
 
@@ -30,7 +45,7 @@ Each of these properties in `config` to specific environment variables or consta
 | refreshTokenPath  |          | Auth service refresh token endpoint                               | `/auth/token/refresh` |
 | userInfoPath      |          | Auth service endpoint to fetch basic user information             | `/auth/userinfo`      |
 
-### Provider
+## Provider
 
 Use the `TailorAuthProvider` component to wrap your application layouts/pages, for instance:
 
@@ -43,9 +58,9 @@ export const Providers = ({ children }: { children: ReactNode }) => (
 );
 ```
 
-### Middlewares
+## Middlewares
 
-#### `withAuth` middleware for Next.js
+### `withAuth` middleware for Next.js
 
 A middleware that mainly intercepts requests to login callback.
 
@@ -75,9 +90,9 @@ const middleware: unknown = withAuth(
 export default middleware;
 ```
 
-### Hooks (client)
+## Hooks (client)
 
-#### `useSession` hook
+### `useSession` hook
 
 A hook to get token in client components.
 
@@ -97,12 +112,14 @@ const Page = () => {
 
 ### `useAuth` hook
 
-A hook that provides authorization functionality. It includes:
+A hook that provides authorization functionality for clients. It includes:
 
 - `login`: A function to redirect to login URL.
 - `refreshToken`: A function to refresh your token.
 
-Here is an example of how to use these functions:
+#### Login
+
+`login` is a function retuned from `useAuth` hook that works as an entrypoint on client components to initialize authentication process.
 
 ```tsx
 "use client";
@@ -111,16 +128,25 @@ import { useAuth } from "@tailor-platform/auth/client";
 // Redirect to `/dashboard` after logging in
 const Component = async () => {
   const { login } = useAuth();
+  const doLogin = useCallback(() => {
+    login({
+      // name is optional, but you can specify one of the following:
+      // * oidc (default)
+      // * saml
+      // * minitailor
+      name: "oidc"
+
+      // options are parameters required in strategies specified in `name` field above.
+      // the fields here will vary on the strategy you use.
+      options: {
+        redirectPath: "/dashboard",
+      }
+    });
+  }, [login])
 
   return (
     <div>
-      <button
-        onClick={() => {
-          login({
-            redirectPath: "/dashboard",
-          });
-        }}
-      >
+      <button onClick={doLogin}>
         Login
       </button>
     </div>
@@ -128,7 +154,7 @@ const Component = async () => {
 };
 ```
 
-#### `usePlatform` hook
+### `usePlatform` hook
 
 The hook that provides utility functions for Tailor Platform specific operation. It includes:
 
@@ -150,9 +176,9 @@ const Component = async () => {
 };
 ```
 
-### Function (server)
+## Function (server)
 
-#### `getServerSession` hook
+### `getServerSession` hook
 
 A function to get token on server components that can be imported from `@tailor-platform/auth/server`.
 
@@ -210,9 +236,9 @@ Strategies are plugin mechanism to add authentication process.
 
 All built-in authentications are also implemented as a strategy. The default is `OIDCStrategy`.
 
-Users can implement their own custom authentication by writing custom strategies. See [src/strategies/abstract.ts](src/strategies/abstract.ts) to know interfaces expected to be implemented.
+### Customization
 
-### Example
+Users can implement their own custom authentication by writing custom strategies. See [src/strategies/abstract.ts](src/strategies/abstract.ts) to know interfaces expected to be implemented.
 
 ```ts
 import { AbstractStrategy } from "@tailor-platform/auth/core";

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.3.0-preview.0",
+  "version": "0.3.0-preview.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.2.1",
+  "version": "0.3.0-preview.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.3.0-preview.1",
+  "version": "0.3.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -50,11 +50,12 @@ export const useAuth = () => {
       case "redirection":
         window.location.replace(result.uri);
         break;
-      case "manual-callback":
-        await fetch(config.loginCallbackPath(strategy.name()), {
-          body: result.payload,
-        });
+      case "manual-callback": {
+        const params = new URLSearchParams(result.payload);
+        const callbackPath = config.loginCallbackPath(strategy.name());
+        window.location.replace(`${callbackPath}?${params.toString()}`);
         break;
+      }
       default:
     }
   };

--- a/packages/auth/src/core/config.ts
+++ b/packages/auth/src/core/config.ts
@@ -1,4 +1,5 @@
 import { OIDCStrategy, SAMLStrategy } from "./strategies/sso";
+import { MinitailorStrategy } from "./strategies/minitailor";
 import { AbstractStrategy } from "@core/strategies/abstract";
 
 type ContextConfig = {
@@ -29,6 +30,7 @@ export class Config {
       Partial<ContextConfig>,
     private readonly strategies: Array<AbstractStrategy> = [
       defaultStrategy,
+      new MinitailorStrategy(),
       new OIDCStrategy(),
       new SAMLStrategy(),
     ],

--- a/packages/auth/src/core/config.ts
+++ b/packages/auth/src/core/config.ts
@@ -67,7 +67,7 @@ export class Config {
 
   loginCallbackPath(strategy?: string) {
     const basePath = this.params.loginCallbackPath || `/login/callback`;
-    return strategy ? basePath + "/" + strategy : basePath;
+    return strategy ? `${basePath}/${strategy}` : basePath;
   }
 
   tokenPath() {

--- a/packages/auth/src/core/config.ts
+++ b/packages/auth/src/core/config.ts
@@ -65,8 +65,9 @@ export class Config {
     return this.params.unauthorizedPath || "/unauthorized";
   }
 
-  loginCallbackPath(strategy: string = defaultStrategy.name()) {
-    return this.params.loginCallbackPath || `/login/callback/${strategy}`;
+  loginCallbackPath(strategy?: string) {
+    const basePath = this.params.loginCallbackPath || `/login/callback`;
+    return strategy ? basePath + "/" + strategy : basePath;
   }
 
   tokenPath() {

--- a/packages/auth/src/core/strategies/abstract.ts
+++ b/packages/auth/src/core/strategies/abstract.ts
@@ -21,7 +21,7 @@ type AuthenticateResult =
       mode: "manual-callback";
 
       // Payload to be sent to callback handler
-      payload: FormData;
+      payload: Record<string, string>;
     };
 
 // AbstractStrategy is an interface that all authentication strategies are expected to implement

--- a/packages/auth/src/core/strategies/minitailor.ts
+++ b/packages/auth/src/core/strategies/minitailor.ts
@@ -1,0 +1,47 @@
+import { AbstractStrategy } from "./abstract";
+import { paramsError } from "@server/middleware/callback";
+import { Config } from "@core/config";
+
+type Options = {
+  email: string;
+  redirectPath: string;
+};
+
+export class MinitailorStrategy implements AbstractStrategy<Options> {
+  name() {
+    return "minitailor";
+  }
+
+  async authenticate(config: Config, options: Options) {
+    const payload = new FormData();
+    payload.append("email", options.email);
+
+    const tokenRawResult = await fetch("http://mini.tailor.tech:18888/token", {
+      method: "POST",
+      body: payload,
+    });
+    const tokenResult = (await tokenRawResult.json()) as { id_token: string };
+    const callbackPayload = new FormData();
+    callbackPayload.append("id_token", tokenResult.id_token);
+    callbackPayload.append("redirect_path", options.redirectPath);
+    return {
+      mode: "manual-callback" as const,
+      payload: callbackPayload,
+    };
+  }
+
+  callback(config: Config, params: URLSearchParams) {
+    const idToken = params.get("id_token");
+    const redirectURI = params.get("redirect_path");
+    if (!idToken || !redirectURI) {
+      throw paramsError();
+    }
+
+    const payload = new FormData();
+    payload.append("id_token", idToken);
+    return {
+      payload,
+      redirectUri: redirectURI,
+    };
+  }
+}

--- a/packages/auth/src/core/strategies/minitailor.ts
+++ b/packages/auth/src/core/strategies/minitailor.ts
@@ -13,12 +13,14 @@ export class MinitailorStrategy implements AbstractStrategy<Options> {
   }
 
   async authenticate(config: Config, options: Options) {
-    const payload = new FormData();
-    payload.append("email", options.email);
-
     const tokenRawResult = await fetch("http://mini.tailor.tech:18888/token", {
       method: "POST",
-      body: payload,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email: options.email,
+      }),
     });
     const tokenResult = (await tokenRawResult.json()) as { id_token: string };
     const callbackPayload = new FormData();

--- a/packages/auth/src/core/strategies/minitailor.ts
+++ b/packages/auth/src/core/strategies/minitailor.ts
@@ -23,12 +23,12 @@ export class MinitailorStrategy implements AbstractStrategy<Options> {
       }),
     });
     const tokenResult = (await tokenRawResult.json()) as { id_token: string };
-    const callbackPayload = new FormData();
-    callbackPayload.append("id_token", tokenResult.id_token);
-    callbackPayload.append("redirect_path", options.redirectPath);
     return {
       mode: "manual-callback" as const,
-      payload: callbackPayload,
+      payload: {
+        id_token: tokenResult.id_token,
+        redirect_path: options.redirectPath,
+      },
     };
   }
 
@@ -39,8 +39,10 @@ export class MinitailorStrategy implements AbstractStrategy<Options> {
       throw paramsError();
     }
 
+    const redirectUri = encodeURI(config.appUrl(config.loginCallbackPath()));
     const payload = new FormData();
     payload.append("id_token", idToken);
+    payload.append("redirect_uri", redirectUri);
     return {
       payload,
       redirectUri: redirectURI,


### PR DESCRIPTION
# Background

Since minitailor supports fake authentication provider, so auth package should also support that.

# Changes

* Add `MinitailorStrategy` as a new authentication strategy
* Fix a bug in manual-callback strategy
