### PR TITLE
feat(minitailorctl): more commands as automatic proxy to tailorctl

### DIFF
--- a/packages/minitailorctl/src/commands.ts
+++ b/packages/minitailorctl/src/commands.ts
@@ -15,9 +15,8 @@ export const runBuiltinCommands = async (args: readonly string[]) => {
     version: string;
     description: string;
   };
-  const logger = new LevelledLogger();
-  const app = program
-    .name("tailordev")
+  program
+    .name("minitailorctl")
     .description(description)
     .option("--verbose", "enable verbosity", false)
     .version(version)

--- a/packages/minitailorctl/src/commands.ts
+++ b/packages/minitailorctl/src/commands.ts
@@ -1,7 +1,7 @@
 import { createRequire } from "node:module";
 import { LevelledLogger } from "./logger.js";
 
-export const runBuiltinCommands = async (args: readonly string[]) => {
+export const getBuiltinCommands = async () => {
   const { Command } = await import("@commander-js/extra-typings");
   const program = new Command();
 
@@ -15,7 +15,9 @@ export const runBuiltinCommands = async (args: readonly string[]) => {
     version: string;
     description: string;
   };
-  program
+  const logger = new LevelledLogger();
+
+  const app = program
     .name("minitailorctl")
     .description(description)
     .option("--verbose", "enable verbosity", false)
@@ -28,5 +30,5 @@ export const runBuiltinCommands = async (args: readonly string[]) => {
       }
     });
 
-  app.parse(args);
+  return app;
 };

--- a/packages/minitailorctl/src/index.ts
+++ b/packages/minitailorctl/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import process from "node:process";
 import { extractProxyCommand, runTailorctl } from "./tailorctl.js";
-import { getBuiltin } from "./commands.js";
+import { getBuiltinCommands } from "./commands.js";
 
 const runCLI = async (argv: readonly string[]) => {
   const proxyCommands = extractProxyCommand(argv);
@@ -9,7 +9,7 @@ const runCLI = async (argv: readonly string[]) => {
     return await runTailorctl(proxyCommands);
   }
 
-  const builtin = await getBuiltin();
+  const builtin = await getBuiltinCommands();
   builtin.parse(argv);
 };
 

--- a/packages/minitailorctl/src/index.ts
+++ b/packages/minitailorctl/src/index.ts
@@ -1,17 +1,16 @@
 #!/usr/bin/env node
 import process from "node:process";
-import { runTailorctl } from "./tailorctl.js";
-import { runBuiltinCommands } from "./commands.js";
+import { extractProxyCommand, runTailorctl } from "./tailorctl.js";
+import { getBuiltin } from "./commands.js";
 
 const runCLI = async (argv: readonly string[]) => {
-  // Run tailorctl proxy mode if splitter ("--") is specified before arguments
-  const proxyArgv = argv.slice(2);
-  if (proxyArgv.length > 0 && proxyArgv[0] === "--") {
-    return await runTailorctl(proxyArgv.slice(1));
+  const proxyCommands = extractProxyCommand(argv);
+  if (proxyCommands !== undefined) {
+    return await runTailorctl(proxyCommands);
   }
 
-  // Run builtin commands otherwise
-  await runBuiltinCommands(argv);
+  const builtin = await getBuiltin();
+  builtin.parse(argv);
 };
 
 await runCLI(process.argv);

--- a/packages/minitailorctl/src/tailorctl.ts
+++ b/packages/minitailorctl/src/tailorctl.ts
@@ -13,7 +13,14 @@ export const runTailorctl = (args: readonly string[]) =>
   });
 
 // Commands specified here is always exuecuted as tailorctl proxy without a splitter
-const specialProxyCommands = ["app", "auth", "config", "cue", "workspace"];
+const specialProxyCommands = [
+  "app",
+  "auth",
+  "config",
+  "cue",
+  "workspace",
+  "alpha",
+];
 
 // Run tailorctl proxy mode if splitter ("--") is specified before arguments
 // But some specific commands listed in `specialProxyCommands` are exception

--- a/packages/minitailorctl/src/tailorctl.ts
+++ b/packages/minitailorctl/src/tailorctl.ts
@@ -1,12 +1,30 @@
 import { execa } from "execa";
 
-export const runTailorctl = (args: string[]) =>
+// Run tailorctl as an independent process with environment variables
+// that are needed to bypass platform authorization on minitailor
+export const runTailorctl = (args: readonly string[]) =>
   execa("tailorctl", args, {
     stdio: "inherit",
     env: {
-      // Environment variables needed to bypass platform authorization on minitailor
       APP_HTTP_SCHEMA: "http",
       PLATFORM_URL: "http://mini.tailor.tech:18090",
       TAILOR_TOKEN: "tpp_11111111111111111111111111111111",
     },
   });
+
+// Commands specified here is always exuecuted as tailorctl proxy without a splitter
+const specialProxyCommands = ["app", "auth", "config", "cue", "workspace"];
+
+// Run tailorctl proxy mode if splitter ("--") is specified before arguments
+// But some specific commands listed in `specialProxyCommands` are exception
+export const extractProxyCommand = (argv: readonly string[]) => {
+  const initialArgv = argv.slice(2);
+  if (initialArgv.length > 0) {
+    const firstCommand = initialArgv[0];
+    if (firstCommand === "--") {
+      return initialArgv.slice(1);
+    } else if (specialProxyCommands.includes(firstCommand)) {
+      return initialArgv;
+    }
+  }
+};


### PR DESCRIPTION
# Background

Got feedback on minitailorctl that adding splitter (`--`) is a bit cumbersome. 

Actually, minitailor is a wrapper CLI for tailorctl so reasonble that it should be working like pnpm for npm, which is also working as a direct command proxy to npm.

# Changes

With this PR, minitailor would execute some tailorctl commands without splitter.

The list is `specialProxyCommands` in changes.
