### PR TITLE
fix(auth): add core to build entries

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/tsup.config.ts
+++ b/packages/auth/tsup.config.ts
@@ -11,7 +11,12 @@ const devOpts =
     : {};
 
 export default defineConfig({
-  entry: ["src/client/index.ts", "src/server/index.ts", "src/adapters/apollo"],
+  entry: [
+    "src/client/index.ts",
+    "src/server/index.ts",
+    "src/core/index.ts",
+    "src/adapters/apollo",
+  ],
   clean: true,
   minify: true,
   format: ["cjs", "esm"],


### PR DESCRIPTION
# Background

I completely forgot to add `core` path in build entries listed in tsup.config.ts

# Changes

Added `core` path in tsup.config.ts
