### PR TITLE
feat(ds): add NumberInput component

### DIFF
--- a/apps/storybook/src/stories/composite/NumberInput.stories.tsx
+++ b/apps/storybook/src/stories/composite/NumberInput.stories.tsx
@@ -1,46 +1,26 @@
-import { NumberInput, type NumberInputRootProps } from "@ark-ui/react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { ChevronDown, ChevronUp } from "lucide-react";
-
-import { numberInput } from "@tailor-platform/styled-system/recipes";
+import {
+  NumberInput,
+  type NumberInputProps,
+} from "@tailor-platform/design-systems";
 
 import { numberInputTypes } from "../../ark-types";
 
 const meta = {
   title: "Composite/NumberInput",
-  component: NumberInput.Root,
+  component: NumberInput,
   parameters: {
     layout: "centered",
   },
   tags: ["autodocs"],
   argTypes: { ...numberInputTypes },
-} satisfies Meta<NumberInputRootProps>;
+} satisfies Meta<NumberInputProps>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const classes = numberInput();
-
 export const Default: Story = {
   render: () => {
-    return (
-      <NumberInput.Root
-        min={-50}
-        max={50}
-        defaultValue="42"
-        className={classes.root}
-      >
-        <NumberInput.Scrubber className={classes.scrubber} />
-        <NumberInput.Input className={classes.input} />
-        <NumberInput.Control className={classes.control}>
-          <NumberInput.IncrementTrigger className={classes.incrementTrigger}>
-            <ChevronUp size={16} />
-          </NumberInput.IncrementTrigger>
-          <NumberInput.DecrementTrigger className={classes.decrementTrigger}>
-            <ChevronDown size={16} />
-          </NumberInput.DecrementTrigger>
-        </NumberInput.Control>
-      </NumberInput.Root>
-    );
+    return <NumberInput min={-50} max={50} defaultValue="43" />;
   },
 };

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.17.1",
+  "version": "0.17.3",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/NumberInput.tsx
+++ b/packages/design-systems/src/components/composite/NumberInput.tsx
@@ -1,0 +1,31 @@
+import {
+  NumberInput as ArkNumberInput,
+  type NumberInputRootProps as ArkNumberInputProps,
+} from "@ark-ui/react";
+import {
+  numberInput,
+  type NumberInputVariantProps,
+} from "@tailor-platform/styled-system/recipes";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+export type NumberInputProps = NumberInputVariantProps & ArkNumberInputProps;
+
+export const NumberInput = (props: NumberInputProps) => {
+  const classes = numberInput();
+  return (
+    <ArkNumberInput.Root className={classes.root} {...props}>
+      <ArkNumberInput.Scrubber className={classes.scrubber} />
+      <ArkNumberInput.Input className={classes.input} />
+      <ArkNumberInput.Control className={classes.control}>
+        <ArkNumberInput.IncrementTrigger className={classes.incrementTrigger}>
+          <ChevronUp size={16} />
+        </ArkNumberInput.IncrementTrigger>
+        <ArkNumberInput.DecrementTrigger className={classes.decrementTrigger}>
+          <ChevronDown size={16} />
+        </ArkNumberInput.DecrementTrigger>
+      </ArkNumberInput.Control>
+    </ArkNumberInput.Root>
+  );
+};
+
+NumberInput.displayName = "NumberInput";

--- a/packages/design-systems/src/index.tsx
+++ b/packages/design-systems/src/index.tsx
@@ -68,3 +68,8 @@ export {
   type DatePickerProps,
 } from "@/components/composite/DatePicker";
 export { Dialog, type DialogProps } from "@/components/composite/Dialog";
+
+export {
+  NumberInput,
+  type NumberInputProps,
+} from "@/components/composite/NumberInput";


### PR DESCRIPTION
# Background
[Bundle ark-ui](https://tailor.atlassian.net/browse/FL-98)

> Currently, our design-systems are not fully self-contained. Some components for example on Storybook requires us to install ark-ui to use implement components.
>
> From viewpoint of Developer Experience, it’s a bit clumsy that developers manually have to install ark-ui on their own side. It should be more like automated by bundling ark-ui with the specific version in design-systems.

<!-- Why is this change necessary, how it came to be? -->

# Changes
- add NumberInput component

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
