### PR TITLE
feat(ds): add Pagination component

### DIFF
--- a/apps/storybook/src/stories/composite/Pagination.stories.tsx
+++ b/apps/storybook/src/stories/composite/Pagination.stories.tsx
@@ -1,24 +1,21 @@
-import { Pagination, type PaginationRootProps } from "@ark-ui/react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
-
-import { Button, IconButton } from "@tailor-platform/design-systems";
-import { pagination } from "@tailor-platform/styled-system/recipes";
+import {
+  Pagination,
+  type PaginationProps,
+} from "@tailor-platform/design-systems";
 import { paginationTypes } from "../../ark-types";
 
-Pagination.Root.displayName = "Pagination";
-
-const classes = pagination();
+Pagination.displayName = "Pagination";
 
 const meta = {
   title: "Composite/Pagination",
-  component: Pagination.Root,
+  component: Pagination,
   parameters: {
     layout: "centered",
   },
   tags: ["autodocs"],
   argTypes: { ...paginationTypes },
-} satisfies Meta<PaginationRootProps>;
+} satisfies Meta<PaginationProps>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -30,49 +27,5 @@ export const Default: Story = {
     siblingCount: 2,
     children: null,
   },
-  render: () => (
-    <Pagination.Root
-      count={50}
-      pageSize={10}
-      siblingCount={1}
-      defaultPage={2}
-      className={classes.root}
-    >
-      {({ pages }) => (
-        <>
-          <Pagination.PrevTrigger asChild>
-            <IconButton variant="tertiary" aria-label="Next Page">
-              <ChevronLeftIcon />
-            </IconButton>
-          </Pagination.PrevTrigger>
-
-          {pages.map((page, index) =>
-            page.type === "page" ? (
-              <Pagination.Item
-                className={classes.item}
-                key={index}
-                {...page}
-                asChild
-              >
-                <Button variant="secondary">{page.value}</Button>
-              </Pagination.Item>
-            ) : (
-              <Pagination.Ellipsis
-                className={classes.ellipsis}
-                key={index}
-                index={index}
-              >
-                &#8230;
-              </Pagination.Ellipsis>
-            ),
-          )}
-          <Pagination.NextTrigger asChild>
-            <IconButton variant="tertiary" aria-label="Next Page">
-              <ChevronRightIcon />
-            </IconButton>
-          </Pagination.NextTrigger>
-        </>
-      )}
-    </Pagination.Root>
-  ),
+  render: (args) => <Pagination {...args} />,
 };

--- a/packages/design-systems/src/components/composite/Pagination.tsx
+++ b/packages/design-systems/src/components/composite/Pagination.tsx
@@ -1,0 +1,59 @@
+import {
+  Pagination as ArkPagination,
+  type PaginationRootProps as ArkPaginationProps,
+} from "@ark-ui/react";
+import {
+  pagination,
+  type PaginationVariantProps,
+} from "@tailor-platform/styled-system/recipes";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { Button } from "../Button";
+import { IconButton } from "../IconButton";
+
+export type PaginationProps = PaginationVariantProps & ArkPaginationProps;
+
+export const Pagination = (props: PaginationProps) => {
+  const { count, ...rest } = props;
+  const classes = pagination();
+  return (
+    <ArkPagination.Root count={count} className={classes.root} {...rest}>
+      {({ pages }) => (
+        <>
+          <ArkPagination.PrevTrigger asChild>
+            <IconButton variant="tertiary" aria-label="Next Page">
+              <ChevronLeftIcon />
+            </IconButton>
+          </ArkPagination.PrevTrigger>
+
+          {pages.map((page, index) =>
+            page.type === "page" ? (
+              <ArkPagination.Item
+                className={classes.item}
+                key={index}
+                {...page}
+                asChild
+              >
+                <Button variant="secondary">{page.value}</Button>
+              </ArkPagination.Item>
+            ) : (
+              <ArkPagination.Ellipsis
+                className={classes.ellipsis}
+                key={index}
+                index={index}
+              >
+                &#8230;
+              </ArkPagination.Ellipsis>
+            ),
+          )}
+          <ArkPagination.NextTrigger asChild>
+            <IconButton variant="tertiary" aria-label="Next Page">
+              <ChevronRightIcon />
+            </IconButton>
+          </ArkPagination.NextTrigger>
+        </>
+      )}
+    </ArkPagination.Root>
+  );
+};
+
+Pagination.displayName = "Pagination";

--- a/packages/design-systems/src/index.tsx
+++ b/packages/design-systems/src/index.tsx
@@ -68,3 +68,8 @@ export {
   type DatePickerProps,
 } from "@/components/composite/DatePicker";
 export { Dialog, type DialogProps } from "@/components/composite/Dialog";
+
+export {
+  Pagination,
+  type PaginationProps,
+} from "@/components/composite/Pagination";


### PR DESCRIPTION
# Background
[Bundle ark-ui](https://tailor.atlassian.net/browse/FL-98)

> Currently, our design-systems are not fully self-contained. Some components for example on Storybook requires us to install ark-ui to use implement components.
>
> From viewpoint of Developer Experience, it’s a bit clumsy that developers manually have to install ark-ui on their own side. It should be more like automated by bundling ark-ui with the specific version in design-systems.

<!-- Why is this change necessary, how it came to be? -->

# Changes
- add pagination component

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
