### PR TITLE
fix(auth): fix strategy fallback

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/src/client/hooks.test.tsx
+++ b/packages/auth/src/client/hooks.test.tsx
@@ -2,13 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { renderHook, waitFor, render, screen } from "@testing-library/react";
 import { Suspense } from "react";
 import { http, HttpResponse } from "msw";
-import {
-  NoCorrespondingStrategyError,
-  clearClientSession,
-  useAuth,
-  usePlatform,
-  useSession,
-} from "./hooks";
+import { clearClientSession, useAuth, usePlatform, useSession } from "./hooks";
 import { TailorAuthProvider } from "./provider";
 import { buildMockServer, mockAuthConfig, mockSession } from "@tests/mocks";
 import { withMockReplace } from "@tests/helper";
@@ -30,29 +24,6 @@ afterAll(() => mockServer.close());
 
 describe("useAuth", () => {
   describe("login", () => {
-    const buildMockedRedirectionURL = (strategy: string) =>
-      `https://mock-api-url.com/mock-login?redirect_uri=http://localhost:3000/mock-callback/${strategy}?redirect_uri=/redirect-path`;
-
-    it.each(["saml", "oidc"])(
-      "redirects to login URL by strategy name (%s)",
-      async (name) => {
-        const replaceMock = vi.fn();
-        await withMockReplace(replaceMock, async () => {
-          const { result } = renderHook(() => useAuth(), {
-            wrapper: mockProvider,
-          });
-          await result.current.login({
-            name,
-            options: { redirectPath: "/redirect-path" },
-          });
-        });
-
-        expect(replaceMock).toHaveBeenCalledWith(
-          buildMockedRedirectionURL(name),
-        );
-      },
-    );
-
     it("works as default strategy if no strategy specified", async () => {
       const replaceMock = vi.fn();
       await withMockReplace(replaceMock, async () => {
@@ -65,19 +36,8 @@ describe("useAuth", () => {
       });
 
       expect(replaceMock).toHaveBeenCalledWith(
-        buildMockedRedirectionURL("default"),
+        "https://mock-api-url.com/mock-login?redirect_uri=http://localhost:3000/mock-callback/default?redirect_uri=/redirect-path",
       );
-    });
-
-    it("raises an error if the unavailable strategy is specified", async () => {
-      const { result } = renderHook(() => useAuth(), {
-        wrapper: mockProvider,
-      });
-      await expect(
-        result.current.login({
-          name: "invalid-strategy",
-        }),
-      ).rejects.toThrow(NoCorrespondingStrategyError);
     });
   });
 

--- a/packages/auth/src/client/hooks.test.tsx
+++ b/packages/auth/src/client/hooks.test.tsx
@@ -42,6 +42,7 @@ describe("useAuth", () => {
             wrapper: mockProvider,
           });
           await result.current.login({
+            name,
             options: { redirectPath: "/redirect-path" },
           });
         });

--- a/packages/auth/src/client/hooks.test.tsx
+++ b/packages/auth/src/client/hooks.test.tsx
@@ -2,7 +2,13 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { renderHook, waitFor, render, screen } from "@testing-library/react";
 import { Suspense } from "react";
 import { http, HttpResponse } from "msw";
-import { clearClientSession, useAuth, usePlatform, useSession } from "./hooks";
+import {
+  NoCorrespondingStrategyError,
+  clearClientSession,
+  useAuth,
+  usePlatform,
+  useSession,
+} from "./hooks";
 import { TailorAuthProvider } from "./provider";
 import { buildMockServer, mockAuthConfig, mockSession } from "@tests/mocks";
 import { withMockReplace } from "@tests/helper";
@@ -24,7 +30,29 @@ afterAll(() => mockServer.close());
 
 describe("useAuth", () => {
   describe("login", () => {
-    it("correctly redirects to the login URL", async () => {
+    const buildMockedRedirectionURL = (strategy: string) =>
+      `https://mock-api-url.com/mock-login?redirect_uri=http://localhost:3000/mock-callback/${strategy}?redirect_uri=/redirect-path`;
+
+    it.each(["saml", "oidc"])(
+      "redirects to login URL by strategy name (%s)",
+      async (name) => {
+        const replaceMock = vi.fn();
+        await withMockReplace(replaceMock, async () => {
+          const { result } = renderHook(() => useAuth(), {
+            wrapper: mockProvider,
+          });
+          await result.current.login({
+            options: { redirectPath: "/redirect-path" },
+          });
+        });
+
+        expect(replaceMock).toHaveBeenCalledWith(
+          buildMockedRedirectionURL(name),
+        );
+      },
+    );
+
+    it("works as default strategy if no strategy specified", async () => {
       const replaceMock = vi.fn();
       await withMockReplace(replaceMock, async () => {
         const { result } = renderHook(() => useAuth(), {
@@ -36,8 +64,19 @@ describe("useAuth", () => {
       });
 
       expect(replaceMock).toHaveBeenCalledWith(
-        "https://mock-api-url.com/mock-login?redirect_uri=http://localhost:3000/mock-callback/default?redirect_uri=/redirect-path",
+        buildMockedRedirectionURL("default"),
       );
+    });
+
+    it("raises an error if the unavailable strategy is specified", async () => {
+      const { result } = renderHook(() => useAuth(), {
+        wrapper: mockProvider,
+      });
+      await expect(
+        result.current.login({
+          name: "invalid-strategy",
+        }),
+      ).rejects.toThrow(NoCorrespondingStrategyError);
     });
   });
 

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -4,7 +4,6 @@ import {
   internalClientSessionPath,
   internalUnauthorizedPath,
 } from "@server/middleware/internal";
-import { defaultStrategy } from "@core/config";
 
 export type UserInfo = {
   sub: string;
@@ -14,9 +13,6 @@ export type UserInfo = {
   email: string;
 };
 
-export const NoCorrespondingStrategyError = new Error(
-  "no corresponding authentication strategy available",
-);
 const NoWindowError = new Error(
   "window object should be available to use this function",
 );
@@ -38,14 +34,8 @@ export const useAuth = () => {
   const login = async (params?: LoginParams) => {
     assertWindowIsAvailable();
 
-    const name = params?.name || defaultStrategy.name();
-    const strategy = config.getStrategy(name);
-    if (!strategy) {
-      throw NoCorrespondingStrategyError;
-    }
-
-    const options = params?.options || {};
-    const result = await strategy.authenticate(config, options);
+    const strategy = config.getStrategy(params?.name);
+    const result = await strategy.authenticate(config, params?.options || {});
     switch (result.mode) {
       case "redirection":
         window.location.replace(result.uri);

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -14,7 +14,7 @@ export type UserInfo = {
   email: string;
 };
 
-const NoCorrespondingStrategyError = new Error(
+export const NoCorrespondingStrategyError = new Error(
   "no corresponding authentication strategy available",
 );
 const NoWindowError = new Error(
@@ -28,7 +28,7 @@ const assertWindowIsAvailable = () => {
 
 type LoginParams = {
   name?: string;
-  options: Record<string, unknown>;
+  options?: Record<string, unknown>;
 };
 
 // useAuth is a hook that abstracts out provider-agnostic interface functions related to authorization

--- a/packages/auth/src/core/config.test.ts
+++ b/packages/auth/src/core/config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { NoCorrespondingStrategyError } from "@core/config";
 import { mockAuthConfig } from "@tests/mocks";
 
 describe("Config", () => {
@@ -7,9 +8,19 @@ describe("Config", () => {
       "returns a corresponding strategy by name (%s)",
       (name) => {
         const strategy = mockAuthConfig.getStrategy(name);
-
         expect(strategy?.name()).toBe(name);
       },
     );
+
+    it("returns default strategy if no name specified", () => {
+      const strategy = mockAuthConfig.getStrategy();
+      expect(strategy.name()).toBe("default");
+    });
+
+    it("raises an error if the unavailable strategy is specified", () => {
+      expect(() => mockAuthConfig.getStrategy("invalid-strategy")).toThrowError(
+        NoCorrespondingStrategyError,
+      );
+    });
   });
 });

--- a/packages/auth/src/core/config.test.ts
+++ b/packages/auth/src/core/config.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { mockAuthConfig } from "@tests/mocks";
+
+describe("Config", () => {
+  describe("getStrategy", () => {
+    it.each(["saml", "oidc", "minitailor"])(
+      "returns a corresponding strategy by name (%s)",
+      (name) => {
+        const strategy = mockAuthConfig.getStrategy(name);
+
+        expect(strategy?.name()).toBe(name);
+      },
+    );
+  });
+});

--- a/packages/auth/src/core/config.ts
+++ b/packages/auth/src/core/config.ts
@@ -86,6 +86,6 @@ export class Config {
   }
 
   secure() {
-    return this.params.secure;
+    return this.params.secure !== false;
   }
 }

--- a/packages/auth/src/core/config.ts
+++ b/packages/auth/src/core/config.ts
@@ -1,6 +1,7 @@
-import { OIDCStrategy, SAMLStrategy } from "./strategies/sso";
-import { MinitailorStrategy } from "./strategies/minitailor";
+import { OIDCStrategy, SAMLStrategy } from "@core/strategies/sso";
+import { MinitailorStrategy } from "@core/strategies/minitailor";
 import { AbstractStrategy } from "@core/strategies/abstract";
+import { defaultStrategy } from "@core/strategies/default";
 
 type ContextConfig = {
   apiHost: string;
@@ -13,13 +14,9 @@ type ContextConfig = {
   userInfoPath: string;
 };
 
-// `defaultStrategy` is a strategy used if users don't specify the strategy name in `login` function
-// Currently, the default is OIDC, but fine to be changed in need.
-export const defaultStrategy = new (class extends OIDCStrategy {
-  name() {
-    return "default";
-  }
-})();
+export const NoCorrespondingStrategyError = new Error(
+  "no corresponding authentication strategy available",
+);
 
 export class Config {
   private readonly strategyMap: Map<string, AbstractStrategy>;
@@ -41,8 +38,13 @@ export class Config {
     });
   }
 
-  getStrategy(name: string) {
-    return this.strategyMap.get(name);
+  getStrategy(name?: string) {
+    const strategyName = name || defaultStrategy.name();
+    const strategy = this.strategyMap.get(strategyName);
+    if (!strategy) {
+      throw NoCorrespondingStrategyError;
+    }
+    return strategy;
   }
 
   getStrategyNames() {

--- a/packages/auth/src/core/config.ts
+++ b/packages/auth/src/core/config.ts
@@ -12,6 +12,7 @@ type ContextConfig = {
   tokenPath: string;
   refreshTokenPath: string;
   userInfoPath: string;
+  secure: boolean;
 };
 
 export const NoCorrespondingStrategyError = new Error(
@@ -82,5 +83,9 @@ export class Config {
 
   userInfoPath() {
     return this.params.userInfoPath || "/auth/userinfo";
+  }
+
+  secure() {
+    return this.params.secure !== false;
   }
 }

--- a/packages/auth/src/core/config.ts
+++ b/packages/auth/src/core/config.ts
@@ -86,6 +86,6 @@ export class Config {
   }
 
   secure() {
-    return this.params.secure !== false;
+    return this.params.secure;
   }
 }

--- a/packages/auth/src/core/strategies/abstract.ts
+++ b/packages/auth/src/core/strategies/abstract.ts
@@ -8,7 +8,7 @@ type CallbackResult = {
   redirectUri: string;
 };
 
-type AuthenticateResult =
+export type AuthenticateResult =
   | {
       // Redirection-base authentication flow (eg. OIDC/SAML/...)
       mode: "redirection";

--- a/packages/auth/src/core/strategies/abstract.ts
+++ b/packages/auth/src/core/strategies/abstract.ts
@@ -8,7 +8,7 @@ type CallbackResult = {
   redirectUri: string;
 };
 
-export type AuthenticateResult =
+type AuthenticateResult =
   | {
       // Redirection-base authentication flow (eg. OIDC/SAML/...)
       mode: "redirection";

--- a/packages/auth/src/core/strategies/default.ts
+++ b/packages/auth/src/core/strategies/default.ts
@@ -1,0 +1,9 @@
+import { OIDCStrategy } from "./sso";
+
+// `defaultStrategy` is a strategy used if users don't specify the strategy name in `login` function
+// Currently, the default is OIDC, but fine to be changed in need.
+export const defaultStrategy = new (class extends OIDCStrategy {
+  name() {
+    return "default";
+  }
+})();

--- a/packages/auth/src/core/strategies/minitailor.ts
+++ b/packages/auth/src/core/strategies/minitailor.ts
@@ -39,7 +39,9 @@ export class MinitailorStrategy implements AbstractStrategy<Options> {
       throw paramsError();
     }
 
-    const redirectUri = encodeURI(config.appUrl(config.loginCallbackPath()));
+    const redirectUri = encodeURI(
+      config.appUrl(config.loginCallbackPath(this.name())),
+    );
     const payload = new FormData();
     payload.append("id_token", idToken);
     payload.append("redirect_uri", redirectUri);

--- a/packages/auth/src/core/strategies/sso.ts
+++ b/packages/auth/src/core/strategies/sso.ts
@@ -32,7 +32,9 @@ export const ssoStrategyBuilder = (name: string, paramName: string) => {
         throw paramsError();
       }
 
-      const redirectUri = encodeURI(config.appUrl(config.loginCallbackPath()));
+      const redirectUri = encodeURI(
+        config.appUrl(config.loginCallbackPath(this.name())),
+      );
       const payload = new FormData();
       payload.append(paramName, param);
       payload.append("redirect_uri", redirectUri);

--- a/packages/auth/src/core/strategies/sso.ts
+++ b/packages/auth/src/core/strategies/sso.ts
@@ -14,7 +14,7 @@ export const ssoStrategyBuilder = (name: string, paramName: string) => {
 
     authenticate(config: Config, options: Options) {
       const apiLoginUrl = config.apiUrl(config.loginPath());
-      const callbackPath = config.loginCallbackPath();
+      const callbackPath = config.loginCallbackPath(this.name());
       const redirectUrl = encodeURI(
         `${config.appUrl(callbackPath)}?redirect_uri=${options.redirectPath ?? "/"}`,
       );

--- a/packages/auth/src/core/strategies/strategy.test.ts
+++ b/packages/auth/src/core/strategies/strategy.test.ts
@@ -1,0 +1,33 @@
+import { defaultStrategy } from "./default";
+import { OIDCStrategy, SAMLStrategy } from "./sso";
+import { mockAuthConfig } from "@tests/mocks";
+
+describe("redirection", () => {
+  const buildMockedRedirectionURL = (strategy: string) =>
+    `https://mock-api-url.com/mock-login?redirect_uri=http://localhost:3000/mock-callback/${strategy}?redirect_uri=/redirect-path`;
+
+  const cases = {
+    default: {
+      builder: () => defaultStrategy,
+      uri: buildMockedRedirectionURL("default"),
+    },
+    oidc: {
+      builder: () => new OIDCStrategy(),
+      uri: buildMockedRedirectionURL("oidc"),
+    },
+    saml: {
+      builder: () => new SAMLStrategy(),
+      uri: buildMockedRedirectionURL("saml"),
+    },
+  } as const;
+
+  it.each(Object.keys(cases))("initializes authentication (%s)", (k) => {
+    const key = k as keyof typeof cases;
+    const strategy = cases[key].builder();
+    const result = strategy.authenticate(mockAuthConfig, {
+      redirectPath: "/redirect-path",
+    });
+
+    expect(result.uri).toBe(cases[key].uri);
+  });
+});

--- a/packages/auth/src/server/middleware/callback.test.ts
+++ b/packages/auth/src/server/middleware/callback.test.ts
@@ -1,7 +1,12 @@
 import { beforeAll, afterAll, afterEach, describe, expect, it } from "vitest";
 import { NextResponse } from "next/server";
 import { HttpResponse, http } from "msw";
-import { callbackHandler, exchangeError, paramsError } from "./callback";
+import {
+  callbackHandler,
+  decideStrategy,
+  exchangeError,
+  paramsError,
+} from "./callback";
 import {
   buildMockServer,
   mockAuthConfig,
@@ -90,5 +95,13 @@ describe("callback", () => {
     await expect(
       callbackHandler({ request, config: authConfig }),
     ).rejects.toThrow(exchangeError(invalidTokenError));
+  });
+});
+
+describe("decideStrategy", () => {
+  it("decides strategy by pathname", () => {
+    const strategy = decideStrategy("/login/callback", mockAuthConfig);
+
+    expect(strategy.name()).toBe("default");
   });
 });

--- a/packages/auth/src/server/middleware/callback.test.ts
+++ b/packages/auth/src/server/middleware/callback.test.ts
@@ -1,13 +1,7 @@
 import { beforeAll, afterAll, afterEach, describe, expect, it } from "vitest";
 import { NextResponse } from "next/server";
 import { HttpResponse, http } from "msw";
-import {
-  EmptyStrategyError,
-  callbackHandler,
-  decideStrategy,
-  exchangeError,
-  paramsError,
-} from "./callback";
+import { callbackHandler, exchangeError, paramsError } from "./callback";
 import {
   buildMockServer,
   mockAuthConfig,
@@ -23,7 +17,9 @@ afterEach(() => mockServer.resetHandlers());
 afterAll(() => mockServer.close());
 
 describe("callback", () => {
-  const baseURL = mockAuthConfig.appUrl(mockAuthConfig.loginCallbackPath());
+  const baseURL = mockAuthConfig.appUrl(
+    mockAuthConfig.loginCallbackPath("default"),
+  );
 
   it("obtains a token and stores it in the cookies", async () => {
     const request = buildRequestWithParams(
@@ -96,24 +92,5 @@ describe("callback", () => {
     await expect(
       callbackHandler({ request, config: authConfig }),
     ).rejects.toThrow(exchangeError(invalidTokenError));
-  });
-});
-
-describe("decideStrategy", () => {
-  it.each(["saml", "oidc", "minitailor"])(
-    "decides strategy by name (%s)",
-    (name) => {
-      const strategy = decideStrategy(
-        `/login/callback/${name}`,
-        mockAuthConfig,
-      );
-      expect(strategy.name()).toBe(name);
-    },
-  );
-
-  it("raises an error if no strategy specified", () => {
-    expect(() =>
-      decideStrategy("/login/callback", mockAuthConfig),
-    ).toThrowError(EmptyStrategyError);
   });
 });

--- a/packages/auth/src/server/middleware/callback.test.ts
+++ b/packages/auth/src/server/middleware/callback.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, afterAll, afterEach, describe, expect, it } from "vitest";
 import { NextResponse } from "next/server";
 import { HttpResponse, http } from "msw";
 import {
+  EmptyStrategyError,
   callbackHandler,
   decideStrategy,
   exchangeError,
@@ -110,9 +111,9 @@ describe("decideStrategy", () => {
     },
   );
 
-  it("fallbacks into default if no applicable strategy decided", () => {
-    const strategy = decideStrategy("/login/callback", mockAuthConfig);
-
-    expect(strategy.name()).toBe("default");
+  it("raises an error if no strategy specified", () => {
+    expect(() =>
+      decideStrategy("/login/callback", mockAuthConfig),
+    ).toThrowError(EmptyStrategyError);
   });
 });

--- a/packages/auth/src/server/middleware/callback.test.ts
+++ b/packages/auth/src/server/middleware/callback.test.ts
@@ -99,7 +99,18 @@ describe("callback", () => {
 });
 
 describe("decideStrategy", () => {
-  it("decides strategy by pathname", () => {
+  it.each(["saml", "oidc", "minitailor"])(
+    "decides strategy by name (%s)",
+    (name) => {
+      const strategy = decideStrategy(
+        `/login/callback/${name}`,
+        mockAuthConfig,
+      );
+      expect(strategy.name()).toBe(name);
+    },
+  );
+
+  it("fallbacks into default if no applicable strategy decided", () => {
     const strategy = decideStrategy("/login/callback", mockAuthConfig);
 
     expect(strategy.name()).toBe("default");

--- a/packages/auth/src/server/middleware/callback.ts
+++ b/packages/auth/src/server/middleware/callback.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { RouteHandler } from "@server/middleware";
 import { ErrorResponse, Session } from "@core/types";
+import { Config } from "@core/config";
 
 export class CallbackError extends Error {
   constructor(
@@ -45,7 +46,7 @@ export const callbackHandler: RouteHandler = async ({
 
   const redirection = NextResponse.redirect(config.appUrl(redirectUri));
   redirection.cookies.set(
-    buildCookieEntry(session, "tailor.token", "access_token"),
+    buildCookieEntry(session, "tailor.token", "access_token", config),
   );
   return redirection;
 };
@@ -54,6 +55,7 @@ const buildCookieEntry = <const T extends keyof Session>(
   session: Session,
   name: string,
   value: T,
+  config: Config,
 ) => {
   // Use the strictest cookie here
   // Here does not manually set `expires` in cookies because token expiration is handled on Tailor Plaform side
@@ -62,6 +64,6 @@ const buildCookieEntry = <const T extends keyof Session>(
     value: session[value],
     sameSite: "strict" as const,
     httpOnly: true,
-    secure: true,
+    secure: config.secure(),
   };
 };

--- a/packages/auth/src/server/middleware/callback.ts
+++ b/packages/auth/src/server/middleware/callback.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { RouteHandler } from "@server/middleware";
 import { ErrorResponse, Session } from "@core/types";
-import { defaultStrategy, Config } from "@core/config";
+import { Config } from "@core/config";
 
 export class CallbackError extends Error {
   constructor(
@@ -18,11 +18,12 @@ export const exchangeError = (reason: string) =>
   new CallbackError("failed-exchange", reason);
 export const noCorrespondingStrategyError = (name: string) =>
   new CallbackError("no-corresponding-strategy", name);
+export const EmptyStrategyError = noCorrespondingStrategyError("<empty>");
 
 export const decideStrategy = (pathname: string, config: Config) => {
   const strategyName = pathname.split("/").pop();
   if (!strategyName || strategyName === "callback") {
-    return defaultStrategy;
+    throw EmptyStrategyError;
   }
 
   const strategy = config.getStrategy(strategyName);

--- a/packages/auth/src/server/middleware/callback.ts
+++ b/packages/auth/src/server/middleware/callback.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { RouteHandler } from "@server/middleware";
 import { ErrorResponse, Session } from "@core/types";
-import { Config } from "@core/config";
 
 export class CallbackError extends Error {
   constructor(
@@ -16,29 +15,14 @@ export const paramsError = () =>
   new CallbackError("invalid-params", "code and redirectURI should be filled");
 export const exchangeError = (reason: string) =>
   new CallbackError("failed-exchange", reason);
-export const noCorrespondingStrategyError = (name: string) =>
-  new CallbackError("no-corresponding-strategy", name);
-export const EmptyStrategyError = noCorrespondingStrategyError("<empty>");
-
-export const decideStrategy = (pathname: string, config: Config) => {
-  const strategyName = pathname.split("/").pop();
-  if (!strategyName || strategyName === "callback") {
-    throw EmptyStrategyError;
-  }
-
-  const strategy = config.getStrategy(strategyName);
-  if (!strategy) {
-    throw noCorrespondingStrategyError(strategyName);
-  }
-  return strategy;
-};
 
 export const callbackHandler: RouteHandler = async ({
   request,
   config,
   options,
 }) => {
-  const strategy = decideStrategy(request.nextUrl.pathname, config);
+  const strategyName = request.nextUrl.pathname.split("/").pop();
+  const strategy = config.getStrategy(strategyName);
   const { payload, redirectUri } = strategy.callback(
     config,
     request.nextUrl.searchParams,

--- a/packages/auth/src/tests/mocks.ts
+++ b/packages/auth/src/tests/mocks.ts
@@ -32,7 +32,7 @@ export const mockAuthConfigValue = {
   apiHost: "https://mock-api-url.com",
   appHost: "http://localhost:3000",
   loginPath: "/mock-login",
-  loginCallbackPath: "/mock-callback/default",
+  loginCallbackPath: "/mock-callback",
   tokenPath: "/mock-token",
   refreshTokenPath: "/mock-refresh-token",
   userInfoPath: "/mock-userinfo",


### PR DESCRIPTION
# Background

Auth package has a bug that oidc/saml callbacks are not working as expected.

They are always getting into the default fallback instead. Minitailor strategy is working fine.

# Changes

* Fix a callback path builder in SSO strategies.
* Add more tests
