### PR TITLE
feat(ds): make lucide-react a peer dependency

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -75,13 +75,13 @@
     "@radix-ui/react-slot": "^1.0.2",
     "@tanstack/react-table": "^8.12.0",
     "deepmerge-ts": "^5.1.0",
-    "lucide-react": "^0.294.0",
     "react-hook-form": "^7.48.2"
   },
   "peerDependencies": {
     "@ark-ui/anatomy": "2.3.1",
     "@ark-ui/react": "2.2.3",
-    "@pandacss/dev": "^0.29.1"
+    "@pandacss/dev": "^0.29.1",
+    "lucide-react": "^0.294.0"
   },
   "prettier": "@tailor-platform/dev-config/prettier"
 }


### PR DESCRIPTION
# Background

Applications may also have their own lucide-react dependency and in that case it would conflict with the one pulled by DS.

# Changes

Move lucide-react from `dependencies` to `peerDependencies`.

# Note

I bumped the minor version number because it felt a bit odd to bump the patch number even though it's not a fix technically. But OTOH, it's not really a feature... or is it?
No strong opinions, please let me know which way is typical for frontend-packages.