### PR TITLE
feat(ds): pinning sticky

### DIFF
--- a/apps/storybook/src/stories/datagrid/DataGridPinedColumnStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridPinedColumnStory.tsx
@@ -17,7 +17,7 @@ export type DataGridPinedColumnStoryProps = {
 
 export const DataGridPinedColumnStory = ({
   enableColumnFilters = false,
-  enableRowSelection = true,
+  enableRowSelection = false,
 }: DataGridPinedColumnStoryProps) => {
   const [rowSelection, setRowSelection] = useState({});
   const table = useDataGrid({

--- a/apps/storybook/src/stories/datagrid/DataGridPinedColumnStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridPinedColumnStory.tsx
@@ -17,7 +17,7 @@ export type DataGridPinedColumnStoryProps = {
 
 export const DataGridPinedColumnStory = ({
   enableColumnFilters = false,
-  enableRowSelection = false,
+  enableRowSelection = true,
 }: DataGridPinedColumnStoryProps) => {
   const [rowSelection, setRowSelection] = useState({});
   const table = useDataGrid({

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/PinnedColumn.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/PinnedColumn.tsx
@@ -43,28 +43,43 @@ export const PinnedColumn = <TData extends Record<string, unknown>>({
           boxShadow="lg"
           position={"absolute"}
           backgroundColor={"bg.default"}
+          display={"flex"}
+          flexDirection={"column"}
+          alignItems={"start"}
         >
           <Button
             variant="link"
             size="xs"
             mb={4}
             onClick={() => {
-              column.pin("right");
+              if (column.getIsPinned() === "right") {
+                column.pin(false);
+              } else {
+                column.pin("right");
+              }
               setIsOpenedPinnedColumnModal(false);
             }}
           >
-            {localization.columnFeatures.pinnedColumn.pinnedRight}
+            {column.getIsPinned() === "right"
+              ? localization.columnFeatures.pinnedColumn.unPin
+              : localization.columnFeatures.pinnedColumn.pinnedRight}
           </Button>
           <Button
             variant="link"
             size="xs"
             mb={4}
             onClick={() => {
-              column.pin("left");
+              if (column.getIsPinned() === "left") {
+                column.pin(false);
+              } else {
+                column.pin("left");
+              }
               setIsOpenedPinnedColumnModal(false);
             }}
           >
-            {localization.columnFeatures.pinnedColumn.pinnedLeft}
+            {column.getIsPinned() === "left"
+              ? localization.columnFeatures.pinnedColumn.unPin
+              : localization.columnFeatures.pinnedColumn.pinnedLeft}
           </Button>
         </Box>
       )}

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -1,7 +1,4 @@
-import {
-  Column as ColumnTanstak,
-  flexRender,
-} from "@tanstack/react-table";
+import { Column as ColumnTanstak, flexRender } from "@tanstack/react-table";
 import { Columns as ColumnsIcon, Filter as FilterIcon } from "lucide-react";
 import { Pagination } from "@ark-ui/react/pagination";
 import {
@@ -74,9 +71,6 @@ export const DataGrid = <TData extends Record<string, unknown>>({
   const getCommonPinningStyles = (
     column: ColumnTanstak<TData>,
   ): CSSProperties => {
-    console.log(column);
-    console.log(column.getStart("left"));
-    console.log(column.getAfter("right"));
     const isPinned = column.getIsPinned();
     const isLastLeftPinnedColumn =
       isPinned === "left" && column.getIsLastColumn("left");

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -1,7 +1,16 @@
-import { flexRender } from "@tanstack/react-table";
+import {
+  Column as ColumnTanstak,
+  flexRender,
+} from "@tanstack/react-table";
 import { Columns as ColumnsIcon, Filter as FilterIcon } from "lucide-react";
 import { Pagination } from "@ark-ui/react/pagination";
-import { DragEvent, useCallback, useEffect, useState } from "react";
+import {
+  CSSProperties,
+  DragEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import { css } from "@tailor-platform/styled-system/css";
 import { pagination, datagrid } from "@tailor-platform/styled-system/recipes";
 import { LOCALIZATION_EN } from "../../../locales/en";
@@ -62,6 +71,33 @@ export const DataGrid = <TData extends Record<string, unknown>>({
     [columnBeingDragged, table],
   );
 
+  const getCommonPinningStyles = (
+    column: ColumnTanstak<TData>,
+  ): CSSProperties => {
+    console.log(column);
+    console.log(column.getStart("left"));
+    console.log(column.getAfter("right"));
+    const isPinned = column.getIsPinned();
+    const isLastLeftPinnedColumn =
+      isPinned === "left" && column.getIsLastColumn("left");
+    const isFirstRightPinnedColumn =
+      isPinned === "right" && column.getIsFirstColumn("right");
+
+    return {
+      boxShadow: isLastLeftPinnedColumn
+        ? "-4px 0 4px -4px gray inset"
+        : isFirstRightPinnedColumn
+          ? "4px 0 4px -4px gray inset"
+          : undefined,
+      left: isPinned === "left" ? `${column.getStart("left")}px` : undefined,
+      right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
+      opacity: isPinned ? 0.95 : 1,
+      position: isPinned ? "sticky" : "relative",
+      zIndex: isPinned ? 1 : 0,
+      backgroundColor: isPinned ? "white" : "inherit",
+    };
+  };
+
   useEffect(() => {
     //Get header titles
     const columnHeaders: Column<TData>[] = [];
@@ -114,7 +150,7 @@ export const DataGrid = <TData extends Record<string, unknown>>({
       </HStack>
 
       <Table className={datagridClasses.table}>
-        <TableHeader>
+        <TableHeader className={datagridClasses.tableHeader}>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow className={datagridClasses.tableRow} key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
@@ -124,6 +160,7 @@ export const DataGrid = <TData extends Record<string, unknown>>({
                   className={datagridClasses.tableHead}
                   style={{
                     width: header.id === "select" ? "54px" : header.getSize(), //First column with checkboxes
+                    ...getCommonPinningStyles(header.column),
                   }}
                   draggable={
                     !table.getState().columnSizingInfo.isResizingColumn
@@ -180,7 +217,7 @@ export const DataGrid = <TData extends Record<string, unknown>>({
             localization={localization}
           />
         )}
-        <TableBody>
+        <TableBody className={datagridClasses.tableBody}>
           {table.getRowModel().rows?.length ? (
             table.getRowModel().rows.map((row) => (
               <TableRow
@@ -192,6 +229,7 @@ export const DataGrid = <TData extends Record<string, unknown>>({
                   <TableCell
                     key={cell.id}
                     className={datagridClasses.tableData}
+                    style={{ ...getCommonPinningStyles(cell.column) }}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.tsx
@@ -229,6 +229,7 @@ export const CustomFilter = <TData extends Record<string, unknown>>(
       boxShadow="lg"
       position={"absolute"}
       backgroundColor={"bg.default"}
+      zIndex={1}
     >
       <Button
         variant="tertiary"

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -65,6 +65,7 @@ export const useDataGrid = <TData extends Record<string, unknown>>({
             }
           />
         ),
+        size: 54,
       });
   }
   const reactTableInstance = useReactTable({

--- a/packages/design-systems/src/locales/en.ts
+++ b/packages/design-systems/src/locales/en.ts
@@ -10,6 +10,7 @@ export const LOCALIZATION_EN: Localization = {
     pinnedColumn: {
       pinnedRight: "Pinned Right",
       pinnedLeft: "Pinned Left",
+      unPin: "Unpin",
     },
   },
   filter: {

--- a/packages/design-systems/src/locales/ja.ts
+++ b/packages/design-systems/src/locales/ja.ts
@@ -10,6 +10,7 @@ export const LOCALIZATION_JA: Localization = {
     pinnedColumn: {
       pinnedRight: "右に固定",
       pinnedLeft: "左に固定",
+      unPin: "元に戻す",
     },
   },
   filter: {

--- a/packages/design-systems/src/locales/types.ts
+++ b/packages/design-systems/src/locales/types.ts
@@ -33,6 +33,7 @@ export interface Localization {
     pinnedColumn: {
       pinnedRight: string;
       pinnedLeft: string;
+      unPin: string;
     };
   };
 }

--- a/packages/design-systems/src/theme/slot-recipes/datagrid.ts
+++ b/packages/design-systems/src/theme/slot-recipes/datagrid.ts
@@ -2,7 +2,15 @@ import { defineSlotRecipe } from "@pandacss/dev";
 
 export const datagrid = defineSlotRecipe({
   className: "datagrid",
-  slots: ["table", "tableRow", "tableHead", "tableData", "tableHeadDivider"],
+  slots: [
+    "table",
+    "tableHeader",
+    "tableRow",
+    "tableHead",
+    "tableBody",
+    "tableData",
+    "tableHeadDivider",
+  ],
   description: "An datagrid style",
   base: {
     table: {
@@ -11,6 +19,10 @@ export const datagrid = defineSlotRecipe({
       borderWidth: "0.5px",
       borderColor: "border.default",
       tableLayout: "fixed",
+    },
+    tableHeader: {
+      position: "relative",
+      zIndex: 1,
     },
     tableRow: {
       fontSize: "12px",
@@ -22,9 +34,14 @@ export const datagrid = defineSlotRecipe({
       borderWidth: "0.5px",
       borderColor: "border.default",
     },
+    tableBody: {
+      position: "relative",
+      zIndex: 0,
+    },
     tableData: {
       borderWidth: "0.5px",
       borderColor: "border.default",
+      wordBreak: "break-word",
     },
     tableHeadDivider: {
       position: "absolute",


### PR DESCRIPTION
# Background

https://tailor.atlassian.net/browse/FL-139
Currently, datagrid supports column pinning, but it shoud be sticky

<!-- Why is this change necessary, how it came to be? -->

# Changes

- add css for sticky
- add the function to remove sticky

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
