### PR TITLE
fix(ds): inherit default pinning state

### DIFF
--- a/apps/storybook/src/stories/datagrid/DataGridPinedColumnStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridPinedColumnStory.tsx
@@ -6,8 +6,9 @@ import {
   DataGridInstance,
   useDataGrid,
 } from "@tailor-platform/design-systems/client";
+import { Button } from "@tailor-platform/design-systems";
 import { Box } from "@tailor-platform/styled-system/jsx";
-import { COLUMNS as columns, DATA as data } from "../../data/datagrid.ts";
+import { COLUMNS as columns, DATA as data } from "../../data/datagrid";
 
 export type DataGridPinedColumnStoryProps = {
   enableColumnFilters?: boolean;
@@ -22,10 +23,23 @@ export const DataGridPinedColumnStory = ({
   const [rowSelection, setRowSelection] = useState({});
   const table = useDataGrid({
     data,
-    columns,
+    columns: [
+      ...columns,
+      {
+        id: "operation",
+        header: "Ops",
+        cell: () => {
+          return <Button>Show</Button>;
+        },
+        size: 100,
+      },
+    ],
     enableColumnFilters,
     enableRowSelection,
     rowSelection,
+    columnPinning: {
+      right: ["operation"],
+    },
     onRowSelectionChange: setRowSelection,
   });
 

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -28,7 +28,7 @@ export const useDataGrid = <TData extends Record<string, unknown>>({
   const { pageIndex = 0, pageSize = 10 } = pagination || {};
   const [columnPinningState, setColumnPinningState] =
     useState<ColumnPinningState>({
-      left: [...(columnPinning?.left || []), "select"],
+      left: ["select", ...(columnPinning?.left || [])],
       right: [...(columnPinning?.right || [])],
     });
 

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -19,16 +19,18 @@ export const useDataGrid = <TData extends Record<string, unknown>>({
   onFilterChange,
   localization,
   columnVisibility,
+  columnPinning,
   onColumnVisibilityChange,
   enableRowSelection = false,
   onRowSelectionChange,
   rowSelection,
 }: UseDataGridProps<TData>): DataGridInstance<TData> => {
   const { pageIndex = 0, pageSize = 10 } = pagination || {};
-  const [columnPinning, setColumnPinning] = useState<ColumnPinningState>({
-    left: ["select"],
-    right: [],
-  });
+  const [columnPinningState, setColumnPinningState] =
+    useState<ColumnPinningState>({
+      left: [...(columnPinning?.left || []), "select"],
+      right: [...(columnPinning?.right || [])],
+    });
 
   const initialState: Record<string, unknown> = {
     pagination: {
@@ -77,13 +79,13 @@ export const useDataGrid = <TData extends Record<string, unknown>>({
     onRowSelectionChange: enableRowSelection ? onRowSelectionChange : undefined,
     state: {
       columnVisibility,
-      columnPinning,
+      columnPinning: columnPinningState,
       rowSelection: enableRowSelection ? rowSelection : {},
     },
     onColumnVisibilityChange,
     enableColumnResizing: true,
     columnResizeMode: "onChange",
-    onColumnPinningChange: setColumnPinning,
+    onColumnPinningChange: setColumnPinningState,
   });
 
   return {


### PR DESCRIPTION
# Background

Currently datagrid does not support default values of column pinning.

# Changes

Use `columnPinning` prop in `useDatagrid` hook to use the default values.
