### PR TITLE
fix(ds): get ids instead of indexes on selecting rows

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -7,7 +7,9 @@ import {
 import { Checkbox } from "../../Checkbox";
 import { type DataGridInstance, type UseDataGridProps } from "./types";
 
-export const useDataGrid = <TData extends Record<string, unknown>>({
+type RowLike = { id: string };
+
+export const useDataGrid = <TData extends RowLike>({
   data,
   columns,
   enablePagination = false,
@@ -32,7 +34,7 @@ export const useDataGrid = <TData extends Record<string, unknown>>({
       right: [...(columnPinning?.right || [])],
     });
 
-  const initialState: Record<string, unknown> = {
+  const initialState = {
     pagination: {
       pageIndex,
       pageSize,
@@ -86,6 +88,7 @@ export const useDataGrid = <TData extends Record<string, unknown>>({
     enableColumnResizing: true,
     columnResizeMode: "onChange",
     onColumnPinningChange: setColumnPinningState,
+    getRowId: (row) => row.id,
   });
 
   return {


### PR DESCRIPTION
# Background

Currently, row selection returns indexes of rows selected, but it is not useful for most apps.

# Changes

Return `id` fields instead.