### PR TITLE
fix(ds): revive indicator stylings

### DIFF
--- a/apps/storybook/src/stories/composite/SegmentGroup.stories.tsx
+++ b/apps/storybook/src/stories/composite/SegmentGroup.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { segmentGroup } from "@tailor-platform/styled-system/recipes";
 import { segmentGroupTypes } from "../../ark-types";
+import { Stack } from "@tailor-platform/design-systems";
 
 SegmentGroup.Root.displayName = "SegmentGroup";
 
@@ -30,24 +31,46 @@ const classes = segmentGroup();
 
 export const Default: Story = {
   render: (props) => (
-    <SegmentGroup.Root
-      className={classes.root}
-      defaultValue="react"
-      orientation="horizontal"
-      {...props}
-    >
-      {options.map((option) => (
-        <SegmentGroup.Item
-          className={classes.item}
-          key={option.id}
-          value={option.id}
-          disabled={option.disabled}
-        >
-          <SegmentGroup.ItemControl />
-          <SegmentGroup.ItemText>{option.label}</SegmentGroup.ItemText>
-        </SegmentGroup.Item>
-      ))}
-      <SegmentGroup.Indicator className={classes.indicator} />
-    </SegmentGroup.Root>
+    <Stack gap={12}>
+      <SegmentGroup.Root
+        className={classes.root}
+        defaultValue="react"
+        orientation="horizontal"
+        {...props}
+      >
+        {options.map((option) => (
+          <SegmentGroup.Item
+            className={classes.item}
+            key={option.id}
+            value={option.id}
+            disabled={option.disabled}
+          >
+            <SegmentGroup.ItemControl />
+            <SegmentGroup.ItemText>{option.label}</SegmentGroup.ItemText>
+          </SegmentGroup.Item>
+        ))}
+        <SegmentGroup.Indicator className={classes.indicator} />
+      </SegmentGroup.Root>
+
+      <SegmentGroup.Root
+        className={classes.root}
+        defaultValue="react"
+        orientation="vertical"
+        {...props}
+      >
+        {options.map((option) => (
+          <SegmentGroup.Item
+            className={classes.item}
+            key={option.id}
+            value={option.id}
+            disabled={option.disabled}
+          >
+            <SegmentGroup.ItemControl />
+            <SegmentGroup.ItemText>{option.label}</SegmentGroup.ItemText>
+          </SegmentGroup.Item>
+        ))}
+        <SegmentGroup.Indicator className={classes.indicator} />
+      </SegmentGroup.Root>
+    </Stack>
   ),
 };

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/theme/slot-recipes/segment-group.ts
+++ b/packages/design-systems/src/theme/slot-recipes/segment-group.ts
@@ -24,15 +24,18 @@ export const segmentGroup = defineSlotRecipe({
       },
     },
     indicator: {
-      borderBottomWidth: {
-        _horizontal: "2px",
-      },
-      borderLeftWidth: {
-        _vertical: "2px",
-      },
       borderColor: "primary.default",
       transform: {
+      },
+      _horizontal: {
+        bottom: '0',
+        borderBottomWidth: '2px',
+        width: 'var(--width)',
         _horizontal: "translateY(1px)",
+      },
+      _vertical: {
+        borderLeftWidth: '2px',
+        height: 'var(--height)',
         _vertical: "translateX(-1px)",
       },
     },

--- a/packages/design-systems/src/theme/slot-recipes/segment-group.ts
+++ b/packages/design-systems/src/theme/slot-recipes/segment-group.ts
@@ -25,17 +25,16 @@ export const segmentGroup = defineSlotRecipe({
     },
     indicator: {
       borderColor: "primary.default",
-      transform: {
-      },
+      transform: {},
       _horizontal: {
-        bottom: '0',
-        borderBottomWidth: '2px',
-        width: 'var(--width)',
+        bottom: "0",
+        borderBottomWidth: "2px",
+        width: "var(--width)",
         _horizontal: "translateY(1px)",
       },
       _vertical: {
-        borderLeftWidth: '2px',
-        height: 'var(--height)',
+        borderLeftWidth: "2px",
+        height: "var(--height)",
         _vertical: "translateX(-1px)",
       },
     },

--- a/packages/design-systems/src/theme/slot-recipes/tabs.ts
+++ b/packages/design-systems/src/theme/slot-recipes/tabs.ts
@@ -42,6 +42,7 @@ export const tabs = defineSlotRecipe({
       height: "2px",
       background: "primary.default",
       bottom: "-1px",
+      width: "var(--width)"
     },
     content: {
       background: "brown.700",

--- a/packages/design-systems/src/theme/slot-recipes/tabs.ts
+++ b/packages/design-systems/src/theme/slot-recipes/tabs.ts
@@ -42,7 +42,7 @@ export const tabs = defineSlotRecipe({
       height: "2px",
       background: "primary.default",
       bottom: "-1px",
-      width: "var(--width)"
+      width: "var(--width)",
     },
     content: {
       background: "brown.700",


### PR DESCRIPTION
# Background
<!-- Why is this change necessary, how it came to be? -->

reviving tabs/segment indicator styles per https://curiosityjp.slack.com/archives/C064WJCNR45/p1710306808659589

# Changes
<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
- fix panda stylings for tabs/segment indicator

<img width="1038" alt="image" src="https://github.com/tailor-platform/frontend-packages/assets/17076187/a08ed0c9-4d1d-42f9-8440-2f859d0640a0">

<img width="1078" alt="image" src="https://github.com/tailor-platform/frontend-packages/assets/17076187/9e475800-48dd-48da-b222-3fe402ab3850">
