### PR TITLE
feat(auth): add logout function

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -174,7 +174,7 @@ const Component = async () => {
 
   return (
     <div>
-      <button onClick={() => logout()}>Login</button>
+      <button onClick={() => logout()}>Logout</button>
     </div>
   );
 };

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -168,7 +168,7 @@ const Component = async () => {
 "use client";
 import { useAuth } from "@tailor-platform/auth/client";
 
-// Redirect to `/dashboard` after logging in
+// Redirect to login path after logged out
 const Component = async () => {
   const { logout } = useAuth();
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -11,6 +11,7 @@ This package provides ways to handle Tailor authentication
   - [`useSession` hook](#usesession-hook)
   - [`useAuth` hook](#useauth-hook)
     - [Login](#login)
+    - [Logout](#logout)
   - [`usePlatform` hook](#useplatform-hook)
 - [Function (server)](#function-server)
   - [`getServerSession` hook](#getserversession-hook)
@@ -154,6 +155,26 @@ const Component = async () => {
   return (
     <div>
       <button onClick={doLogin}>Login</button>
+    </div>
+  );
+};
+```
+
+#### Logout
+
+`logout` is a function to delete a session token to get logged out.
+
+```tsx
+"use client";
+import { useAuth } from "@tailor-platform/auth/client";
+
+// Redirect to `/dashboard` after logging in
+const Component = async () => {
+  const { logout } = useAuth();
+
+  return (
+    <div>
+      <button onClick={() => logout()}>Login</button>
     </div>
   );
 };

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.4.0-preview.0",
+  "version": "0.4.0-preview.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.4.0",
+  "version": "0.4.0-preview.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.5.0-preview.0",
+  "version": "0.5.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.4.0-preview.1",
+  "version": "0.5.0-preview.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -29,6 +29,10 @@ type LoginParams = {
   options?: Record<string, unknown>;
 };
 
+type LogoutParams = {
+  redirectPath?: string;
+};
+
 // useAuth is a hook that abstracts out provider-agnostic interface functions related to authorization
 export const useAuth = () => {
   const config = useTailorAuth();
@@ -52,9 +56,15 @@ export const useAuth = () => {
     }
   };
 
-  const logout = () => {
+  const logout = (params?: LogoutParams) => {
     assertWindowIsAvailable();
-    window.location.replace(config.appUrl(internalLogoutPath));
+
+    const searchParams = new URLSearchParams({
+      redirect_path: params?.redirectPath || config.loginPath(),
+    });
+    window.location.replace(
+      `${config.appUrl(internalLogoutPath)}?${searchParams.toString()}`,
+    );
   };
 
   const refreshToken = async (

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -3,6 +3,7 @@ import { useTailorAuth } from "@client/provider";
 import {
   callbackByStrategy,
   internalClientSessionPath,
+  internalLogoutPath,
   internalUnauthorizedPath,
 } from "@server/middleware/internal";
 
@@ -51,6 +52,11 @@ export const useAuth = () => {
     }
   };
 
+  const logout = () => {
+    assertWindowIsAvailable();
+    window.location.replace(config.appUrl(internalLogoutPath));
+  };
+
   const refreshToken = async (
     refreshToken: string,
   ): Promise<SessionResult | ErrorResponse> => {
@@ -68,6 +74,7 @@ export const useAuth = () => {
 
   return {
     login,
+    logout,
     refreshToken,
   };
 };

--- a/packages/auth/src/server/middleware.ts
+++ b/packages/auth/src/server/middleware.ts
@@ -5,6 +5,8 @@ import {
   internalCallbackPath,
   internalClientSessionHandler,
   internalClientSessionPath,
+  internalLogoutHandler,
+  internalLogoutPath,
   internalUnauthorizedPath,
   internalUnauthroziedHandler,
 } from "./middleware/internal";
@@ -32,6 +34,7 @@ export const withAuth =
         [internalCallbackPath]: callbackHandler,
         [internalClientSessionPath]: internalClientSessionHandler,
         [internalUnauthorizedPath]: internalUnauthroziedHandler,
+        [internalLogoutPath]: internalLogoutHandler,
       },
       async () => {
         await middleware?.(request, event);

--- a/packages/auth/src/server/middleware/internal.ts
+++ b/packages/auth/src/server/middleware/internal.ts
@@ -26,6 +26,8 @@ export const internalUnauthroziedHandler: RouteHandler = ({ config }) =>
 // This function deletes the token from cookies and redirects to the login page.
 export const internalLogoutPath = "/__auth/logout" as const;
 export const internalLogoutHandler: RouteHandler = ({ request, config }) => {
+  const redirectPath =
+    request.nextUrl.searchParams.get("redirect_path") || config.loginPath();
   request.cookies.delete("tailor.token");
-  return NextResponse.redirect(config.appUrl(config.loginPath()));
+  return NextResponse.redirect(config.appUrl(redirectPath));
 };

--- a/packages/auth/src/server/middleware/internal.ts
+++ b/packages/auth/src/server/middleware/internal.ts
@@ -21,3 +21,11 @@ export const internalClientSessionHandler: RouteHandler = ({ request }) => {
 export const internalUnauthorizedPath = "/__auth/unauthorized" as const;
 export const internalUnauthroziedHandler: RouteHandler = ({ config }) =>
   NextResponse.redirect(config.appUrl(config.unauthorizedPath()));
+
+// Internal path to logout from client components
+// This function deletes the token from cookies and redirects to the login page.
+export const internalLogoutPath = "/__auth/logout" as const;
+export const internalLogoutHandler: RouteHandler = ({ request, config }) => {
+  request.cookies.delete("tailor.token");
+  return NextResponse.redirect(config.appUrl(config.loginPath()));
+};

--- a/packages/auth/src/server/middleware/internal.ts
+++ b/packages/auth/src/server/middleware/internal.ts
@@ -28,6 +28,7 @@ export const internalLogoutPath = "/__auth/logout" as const;
 export const internalLogoutHandler: RouteHandler = ({ request, config }) => {
   const redirectPath =
     request.nextUrl.searchParams.get("redirect_path") || config.loginPath();
-  request.cookies.delete("tailor.token");
-  return NextResponse.redirect(config.appUrl(redirectPath));
+  const redirection = NextResponse.redirect(config.appUrl(redirectPath));
+  redirection.cookies.delete("tailor.token");
+  return redirection;
 };


### PR DESCRIPTION
# Background

No logout feature is implemented in auth package

# Changes

This pull request primarily focuses on adding the logout functionality to the `@tailor-platform/auth` package. The most significant changes include the addition of the `logout` function in the `useAuth` hook, the creation of the `LogoutParams` type, and the introduction of the internal logout path and handler. Additionally, the package version has been updated to reflect these changes.

Here are the key changes:

**Logout Functionality:**

* [`packages/auth/README.md`](diffhunk://#diff-267aa09f91d442d8d9a4868e2fd7948555387a236edace3b0c72b35948da90a8R14): Added documentation for the new `logout` function, which deletes a session token to log out a user. [[1]](diffhunk://#diff-267aa09f91d442d8d9a4868e2fd7948555387a236edace3b0c72b35948da90a8R14) [[2]](diffhunk://#diff-267aa09f91d442d8d9a4868e2fd7948555387a236edace3b0c72b35948da90a8R163-R182)
* [`packages/auth/src/client/hooks.ts`](diffhunk://#diff-1dfa41d6294f9c71b94051574daaf578d5b857d293c03c4f18553b3a8059f32aR6): Introduced the `LogoutParams` type and added the `logout` function in the `useAuth` hook. This function redirects the user to the login page after logging out. [[1]](diffhunk://#diff-1dfa41d6294f9c71b94051574daaf578d5b857d293c03c4f18553b3a8059f32aR6) [[2]](diffhunk://#diff-1dfa41d6294f9c71b94051574daaf578d5b857d293c03c4f18553b3a8059f32aR32-R35) [[3]](diffhunk://#diff-1dfa41d6294f9c71b94051574daaf578d5b857d293c03c4f18553b3a8059f32aR59-R69) [[4]](diffhunk://#diff-1dfa41d6294f9c71b94051574daaf578d5b857d293c03c4f18553b3a8059f32aR87)
* [`packages/auth/src/server/middleware/internal.ts`](diffhunk://#diff-24559462a2cbfde34fcc77c85adac105ee3ca149f2e3a83d91c0397ba12db5b6R24-R34): Added the internal logout path and handler. This function deletes the token from cookies and redirects to the login page.
* [`packages/auth/src/server/middleware.ts`](diffhunk://#diff-2e090b44c7a207269efd9a4f21be7e8dfee962b26bb9e32fda4fb269a1eae3d7R8-R9): Included the internal logout handler in the `withAuth` export. [[1]](diffhunk://#diff-2e090b44c7a207269efd9a4f21be7e8dfee962b26bb9e32fda4fb269a1eae3d7R8-R9) [[2]](diffhunk://#diff-2e090b44c7a207269efd9a4f21be7e8dfee962b26bb9e32fda4fb269a1eae3d7R37)

**Package Version Update:**

* [`packages/auth/package.json`](diffhunk://#diff-79fbe1d958aec3ec2b3d46cdc5b9b34cd834f48550895ce9484f10c0f77a4a8fL3-R3): Updated the package version from `0.4.0` to `0.5.0` to reflect the addition of the logout functionality.