### PR TITLE
chore(auth): removed loginCallbackPath fron configuration

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -32,7 +32,9 @@ export const config = new Config({
 });
 ```
 
-Each of these properties in `config` to specific environment variables or constants you need to define in your application's environment. Collectively, they form the configuration necessary for the client to handle user authentication in a standardized manner.
+Each of these properties in `config` to specific environment variables or constants you need to define in your application's environment. 
+
+Collectively, they form the configuration necessary for the client to handle user authentication in a standardized manner.
 
 | Name             | Required | Description                                           | Default               |
 | ---------------- | -------- | ----------------------------------------------------- | --------------------- |

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -3,6 +3,7 @@
 This package provides ways to handle Tailor authentication
 
 - [Configuration](#configuration)
+  - [Callback](#callback)
 - [Provider](#provider)
 - [Middlewares](#middlewares)
   - [`withAuth` middleware for Next.js](#withauth-middleware-for-nextjs)
@@ -42,6 +43,12 @@ Each of these properties in `config` to specific environment variables or consta
 | tokenPath        |          | Auth service endpoint to issue a session token        | `/auth/token`         |
 | refreshTokenPath |          | Auth service refresh token endpoint                   | `/auth/token/refresh` |
 | userInfoPath     |          | Auth service endpoint to fetch basic user information | `/auth/userinfo`      |
+
+### Callback
+
+This package automatically adds a callback path by Next.js middleware to accept redirection from Identity Providers as `__auth/callback/{strategy}`.
+
+Thus, if you are using OIDC strategy, the path you have to add in the whitelist on IDP dashboard will be `__auth/callback/oidc`.
 
 ## Provider
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -46,7 +46,7 @@ Each of these properties in `config` to specific environment variables or consta
 
 ### Callback
 
-This package automatically adds a callback path by Next.js middleware to accept redirection from Identity Providers as `__auth/callback/{strategy}`.
+This package automatically generates a callback handler with Next.js middleware to accept redirection from Identity Providers as `__auth/callback/{strategy}`.
 
 Thus, if you are using OIDC strategy, the path you have to add in the whitelist on IDP dashboard will be `__auth/callback/oidc`.
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -33,16 +33,15 @@ export const config = new Config({
 
 Each of these properties in `config` to specific environment variables or constants you need to define in your application's environment. Collectively, they form the configuration necessary for the client to handle user authentication in a standardized manner.
 
-| Name              | Required | Description                                                       | Default               |
-| ----------------- | -------- | ----------------------------------------------------------------- | --------------------- |
-| apiHost           | Yes      | Tailor Platform host                                              |                       |
-| appHost           | Yes      | Frontend app host                                                 |                       |
-| loginPath         |          | Path the auth provider will redirect the user to after signing in | `/auth/login`         |
-| unauthorizedPath  |          | Path to be redirected if not authorized                           | `/unauthorized`       |
-| loginCallbackPath |          | Auth service login endpoint                                       | `/login/callback`     |
-| tokenPath         |          | Auth service token endpoint                                       | `/auth/token`         |
-| refreshTokenPath  |          | Auth service refresh token endpoint                               | `/auth/token/refresh` |
-| userInfoPath      |          | Auth service endpoint to fetch basic user information             | `/auth/userinfo`      |
+| Name              | Required | Description                                            | Default               |
+| ----------------- | -------- | ------------------------------------------------------ | --------------------- |
+| apiHost           | Yes      | Tailor Platform host                                   |                       |
+| appHost           | Yes      | Frontend app host                                      |                       |
+| unauthorizedPath  |          | Path to be redirected if not authorized                | `/unauthorized`       |
+| loginPath         |          | Auth service endpoint to initiate login                | `/auth/login`         |
+| tokenPath         |          | Auth service endpoint to issue a session token         | `/auth/token`         |
+| refreshTokenPath  |          | Auth service refresh token endpoint                    | `/auth/token/refresh` |
+| userInfoPath      |          | Auth service endpoint to fetch basic user information  | `/auth/userinfo`      |
 
 ## Provider
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -32,7 +32,7 @@ export const config = new Config({
 });
 ```
 
-Each of these properties in `config` to specific environment variables or constants you need to define in your application's environment. 
+Each of these properties in `config` to specific environment variables or constants you need to define in your application's environment.
 
 Collectively, they form the configuration necessary for the client to handle user authentication in a standardized manner.
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -33,15 +33,15 @@ export const config = new Config({
 
 Each of these properties in `config` to specific environment variables or constants you need to define in your application's environment. Collectively, they form the configuration necessary for the client to handle user authentication in a standardized manner.
 
-| Name              | Required | Description                                            | Default               |
-| ----------------- | -------- | ------------------------------------------------------ | --------------------- |
-| apiHost           | Yes      | Tailor Platform host                                   |                       |
-| appHost           | Yes      | Frontend app host                                      |                       |
-| unauthorizedPath  |          | Path to be redirected if not authorized                | `/unauthorized`       |
-| loginPath         |          | Auth service endpoint to initiate login                | `/auth/login`         |
-| tokenPath         |          | Auth service endpoint to issue a session token         | `/auth/token`         |
-| refreshTokenPath  |          | Auth service refresh token endpoint                    | `/auth/token/refresh` |
-| userInfoPath      |          | Auth service endpoint to fetch basic user information  | `/auth/userinfo`      |
+| Name             | Required | Description                                           | Default               |
+| ---------------- | -------- | ----------------------------------------------------- | --------------------- |
+| apiHost          | Yes      | Tailor Platform host                                  |                       |
+| appHost          | Yes      | Frontend app host                                     |                       |
+| unauthorizedPath |          | Path to be redirected if not authorized               | `/unauthorized`       |
+| loginPath        |          | Auth service endpoint to initiate login               | `/auth/login`         |
+| tokenPath        |          | Auth service endpoint to issue a session token        | `/auth/token`         |
+| refreshTokenPath |          | Auth service refresh token endpoint                   | `/auth/token/refresh` |
+| userInfoPath     |          | Auth service endpoint to fetch basic user information | `/auth/userinfo`      |
 
 ## Provider
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/src/client/hooks.test.tsx
+++ b/packages/auth/src/client/hooks.test.tsx
@@ -36,7 +36,7 @@ describe("useAuth", () => {
       });
 
       expect(replaceMock).toHaveBeenCalledWith(
-        "https://mock-api-url.com/mock-login?redirect_uri=http://localhost:3000/mock-callback/default?redirect_uri=/redirect-path",
+        "https://mock-api-url.com/mock-login?redirect_uri=http://localhost:3000/__auth/callback/default?redirect_uri=/redirect-path",
       );
     });
   });

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -1,6 +1,7 @@
 import { ErrorResponse, SessionOption, SessionResult } from "@core/types";
 import { useTailorAuth } from "@client/provider";
 import {
+  callbackByStrategy,
   internalClientSessionPath,
   internalUnauthorizedPath,
 } from "@server/middleware/internal";
@@ -42,7 +43,7 @@ export const useAuth = () => {
         break;
       case "manual-callback": {
         const params = new URLSearchParams(result.payload);
-        const callbackPath = config.loginCallbackPath(strategy.name());
+        const callbackPath = callbackByStrategy(strategy.name());
         window.location.replace(`${callbackPath}?${params.toString()}`);
         break;
       }

--- a/packages/auth/src/core/config.ts
+++ b/packages/auth/src/core/config.ts
@@ -8,7 +8,6 @@ type ContextConfig = {
   appHost: string;
   loginPath: string;
   unauthorizedPath: string;
-  loginCallbackPath: string;
   tokenPath: string;
   refreshTokenPath: string;
   userInfoPath: string;
@@ -66,11 +65,6 @@ export class Config {
 
   unauthorizedPath() {
     return this.params.unauthorizedPath || "/unauthorized";
-  }
-
-  loginCallbackPath(strategy?: string) {
-    const basePath = this.params.loginCallbackPath || `/login/callback`;
-    return strategy ? `${basePath}/${strategy}` : basePath;
   }
 
   tokenPath() {

--- a/packages/auth/src/core/strategies/minitailor.ts
+++ b/packages/auth/src/core/strategies/minitailor.ts
@@ -1,6 +1,7 @@
 import { AbstractStrategy } from "./abstract";
 import { paramsError } from "@server/middleware/callback";
 import { Config } from "@core/config";
+import { callbackByStrategy } from "@server/middleware/internal";
 
 type Options = {
   email: string;
@@ -40,7 +41,7 @@ export class MinitailorStrategy implements AbstractStrategy<Options> {
     }
 
     const redirectUri = encodeURI(
-      config.appUrl(config.loginCallbackPath(this.name())),
+      config.appUrl(callbackByStrategy(this.name())),
     );
     const payload = new FormData();
     payload.append("id_token", idToken);

--- a/packages/auth/src/core/strategies/sso.ts
+++ b/packages/auth/src/core/strategies/sso.ts
@@ -1,6 +1,7 @@
 import { AbstractStrategy } from "./abstract";
 import { Config } from "@core/config";
 import { paramsError } from "@server/middleware/callback";
+import { callbackByStrategy } from "@server/middleware/internal";
 
 export type Options = { redirectPath: string };
 
@@ -14,7 +15,7 @@ export const ssoStrategyBuilder = (name: string, paramName: string) => {
 
     authenticate(config: Config, options: Options) {
       const apiLoginUrl = config.apiUrl(config.loginPath());
-      const callbackPath = config.loginCallbackPath(this.name());
+      const callbackPath = callbackByStrategy(this.name());
       const redirectUrl = encodeURI(
         `${config.appUrl(callbackPath)}?redirect_uri=${options.redirectPath ?? "/"}`,
       );
@@ -33,7 +34,7 @@ export const ssoStrategyBuilder = (name: string, paramName: string) => {
       }
 
       const redirectUri = encodeURI(
-        config.appUrl(config.loginCallbackPath(this.name())),
+        config.appUrl(callbackByStrategy(this.name())),
       );
       const payload = new FormData();
       payload.append(paramName, param);

--- a/packages/auth/src/core/strategies/strategy.test.ts
+++ b/packages/auth/src/core/strategies/strategy.test.ts
@@ -4,7 +4,7 @@ import { mockAuthConfig } from "@tests/mocks";
 
 describe("redirection", () => {
   const buildMockedRedirectionURL = (strategy: string) =>
-    `https://mock-api-url.com/mock-login?redirect_uri=http://localhost:3000/mock-callback/${strategy}?redirect_uri=/redirect-path`;
+    `https://mock-api-url.com/mock-login?redirect_uri=http://localhost:3000/__auth/callback/${strategy}?redirect_uri=/redirect-path`;
 
   const cases = {
     default: {

--- a/packages/auth/src/server/middleware.ts
+++ b/packages/auth/src/server/middleware.ts
@@ -2,6 +2,7 @@ import { NextMiddleware, NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { callbackHandler } from "./middleware/callback";
 import {
+  internalCallbackPath,
   internalClientSessionHandler,
   internalClientSessionPath,
   internalUnauthorizedPath,
@@ -28,7 +29,7 @@ export const withAuth =
       { request, config, options },
       {
         // Add middleware routes here
-        [config.loginCallbackPath()]: callbackHandler,
+        [internalCallbackPath]: callbackHandler,
         [internalClientSessionPath]: internalClientSessionHandler,
         [internalUnauthorizedPath]: internalUnauthroziedHandler,
       },

--- a/packages/auth/src/server/middleware/callback.test.ts
+++ b/packages/auth/src/server/middleware/callback.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, afterAll, afterEach, describe, expect, it } from "vitest";
 import { NextResponse } from "next/server";
 import { HttpResponse, http } from "msw";
 import { callbackHandler, exchangeError, paramsError } from "./callback";
+import { callbackByStrategy } from "./internal";
 import {
   buildMockServer,
   mockAuthConfig,
@@ -17,9 +18,7 @@ afterEach(() => mockServer.resetHandlers());
 afterAll(() => mockServer.close());
 
 describe("callback", () => {
-  const baseURL = mockAuthConfig.appUrl(
-    mockAuthConfig.loginCallbackPath("default"),
-  );
+  const baseURL = mockAuthConfig.appUrl(callbackByStrategy("default"));
 
   it("obtains a token and stores it in the cookies", async () => {
     const request = buildRequestWithParams(

--- a/packages/auth/src/server/middleware/internal.ts
+++ b/packages/auth/src/server/middleware/internal.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { RouteHandler } from "@server/middleware";
 
+// Internal path to handle callback from the identity provider
+export const internalCallbackPath = "/__auth/callback" as const;
+export const callbackByStrategy = (strategy: string = "default") =>
+  `/__auth/callback/${strategy}` as const;
+
 // Internal path to fetch token from client components
 // `useSession` hook fetches token from this endpoint by extracting it from cookies.
 export const internalClientSessionPath = "/__auth/session" as const;


### PR DESCRIPTION
# Background

Users don't have any motivation to customize callback path, so this PR unexposes the configuration and make it internal.

# Changes

This pull request primarily involves changes to the authentication process in the `packages/auth` directory. The most significant changes are the removal of `loginCallbackPath` from `ContextConfig` and `Config` classes, and the introduction of `callbackByStrategy` function. This function generates the callback path based on the authentication strategy, replacing the previously hardcoded `loginCallbackPath`. Other changes include updates to the `README.md` file to reflect these modifications and adjustments in test files to account for the new callback paths.

Changes to configuration and callback paths:

* [`packages/auth/src/core/config.ts`](diffhunk://#diff-5166aeb24926154c34a748222be317cf042e0b60df932bc3124bf2a859196653L11): Removed `loginCallbackPath` from `ContextConfig` and `Config` classes. The `loginCallbackPath` method has also been removed from the `Config` class. [[1]](diffhunk://#diff-5166aeb24926154c34a748222be317cf042e0b60df932bc3124bf2a859196653L11) [[2]](diffhunk://#diff-5166aeb24926154c34a748222be317cf042e0b60df932bc3124bf2a859196653L71-L75)
* [`packages/auth/src/server/middleware/internal.ts`](diffhunk://#diff-24559462a2cbfde34fcc77c85adac105ee3ca149f2e3a83d91c0397ba12db5b6R4-R8): Added `internalCallbackPath` constant and `callbackByStrategy` function to generate callback paths based on authentication strategy.

Updates to authentication strategies:

* [`packages/auth/src/core/strategies/sso.ts`](diffhunk://#diff-e2c6d19931678e76efce305cd3b25871f85169c7f9b4c4dd77ec6d13cf3ec9caL17-R18): Replaced usage of `config.loginCallbackPath` with `callbackByStrategy` function in `ssoStrategyBuilder`. [[1]](diffhunk://#diff-e2c6d19931678e76efce305cd3b25871f85169c7f9b4c4dd77ec6d13cf3ec9caL17-R18) [[2]](diffhunk://#diff-e2c6d19931678e76efce305cd3b25871f85169c7f9b4c4dd77ec6d13cf3ec9caL36-R37)
* [`packages/auth/src/client/hooks.ts`](diffhunk://#diff-1dfa41d6294f9c71b94051574daaf578d5b857d293c03c4f18553b3a8059f32aL45-R46): Replaced usage of `config.loginCallbackPath` with `callbackByStrategy` function in `useAuth`.

Adjustments in test files:

* [`packages/auth/src/client/hooks.test.tsx`](diffhunk://#diff-14dda08b1f46c69de796284f6b62e52ef480ff0ff760d479d87830bf812b3c47L39-R39): Updated expected URL in `useAuth` test to reflect new callback path.
* [`packages/auth/src/core/strategies/strategy.test.ts`](diffhunk://#diff-0b1d3f52b5b7b549e7e93c96f1c99ae7abbbc9217191b5f5c4ab565c84970e7cL7-R7): Updated `buildMockedRedirectionURL` function to use new callback path.
* [`packages/auth/src/server/middleware/callback.test.ts`](diffhunk://#diff-51e47f158e8dd426e2b24df54f50fef01f16daa96f9d3f698ea8f51a733daf2dL20-R21): Updated `baseURL` in `callback` test to use new callback path.