### PR TITLE
Feature/datagrid pagination

### DIFF
--- a/apps/storybook/src/stories/datagrid/DataGridPagination.stories.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridPagination.stories.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+import {
+  DataGridPaginationStory,
+  DataGridPaginationStoryProps,
+} from "./DataGridPaginationStory.tsx";
+import dataGridPaginationStorySource from "./DataGridPaginationStory.tsx?raw";
+
+const meta: Meta<DataGridPaginationStoryProps> = {
+  title: "Datagrid/Pagination Datagrid",
+  component: DataGridPaginationStory,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    pageSize: { control: "number"}
+  },
+};
+
+export default meta;
+type Story = StoryObj<DataGridPaginationStoryProps>;
+
+export const Default: Story = {
+  args: {
+    pageSize: 5,    
+  },
+  render: (args) => <DataGridPaginationStory {...args} />,
+  parameters: {
+    docs: {
+      canvas: {
+        sourceState: "hidden",
+      },
+      source: {
+        code: dataGridPaginationStorySource,
+      },
+    },
+  },
+};

--- a/apps/storybook/src/stories/datagrid/DataGridPagination.stories.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridPagination.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<DataGridPaginationStoryProps> = {
   },
   tags: ["autodocs"],
   argTypes: {
-    pageSize: { control: "number"}
+    pageSize: { control: "number" },
   },
 };
 
@@ -25,7 +25,7 @@ type Story = StoryObj<DataGridPaginationStoryProps>;
 
 export const Default: Story = {
   args: {
-    pageSize: 5,    
+    pageSize: 5,
   },
   render: (args) => <DataGridPaginationStory {...args} />,
   parameters: {

--- a/apps/storybook/src/stories/datagrid/DataGridPaginationStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridPaginationStory.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Box } from "@tailor-platform/design-systems";
+import {
+  DataGrid,
+  DataGridInstance,
+  useDataGrid,
+} from "@tailor-platform/design-systems/client";
+
+import { COLUMNS as columns, DATA as data } from "../../data/datagrid.ts";
+
+export type DataGridPaginationStoryProps = {
+  pageSize: number;
+  table?: DataGridInstance<Record<string, unknown>>;
+};
+
+export const DataGridPaginationStory = ({
+  pageSize = 5,
+}: DataGridPaginationStoryProps) => {
+  const table = useDataGrid({
+    data,
+    columns,
+    enablePagination: true,
+    pagination: {
+      pageIndex: 0,
+      pageSize,
+    },
+  });
+
+  return (
+    <Box w="full" style={{ marginTop: "50px" }}>
+      <DataGrid table={table} />
+    </Box>
+  );
+};
+
+DataGridPaginationStory.displayName = "PaginationDataGrid";

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/Button.tsx
+++ b/packages/design-systems/src/components/Button.tsx
@@ -17,7 +17,7 @@ type ButtonContentProps = {
   leftIcon?: ReactElement;
   rightIcon?: ReactElement;
   href?: string;
-  "data-disabled"?: string
+  "data-disabled"?: string;
 };
 
 export type ButtonProps = ButtonVariantProps &
@@ -28,7 +28,7 @@ export type ButtonProps = ButtonVariantProps &
 
 export const Button = (props: ButtonProps) => {
   const { variant, href, size, leftIcon, rightIcon, children, ...rest } = props;
-  delete rest?.["data-disabled"]
+  delete rest?.["data-disabled"];
 
   if (href) {
     return (

--- a/packages/design-systems/src/components/Button.tsx
+++ b/packages/design-systems/src/components/Button.tsx
@@ -17,6 +17,7 @@ type ButtonContentProps = {
   leftIcon?: ReactElement;
   rightIcon?: ReactElement;
   href?: string;
+  "data-disabled"?: string
 };
 
 export type ButtonProps = ButtonVariantProps &
@@ -27,6 +28,7 @@ export type ButtonProps = ButtonVariantProps &
 
 export const Button = (props: ButtonProps) => {
   const { variant, href, size, leftIcon, rightIcon, children, ...rest } = props;
+  delete rest?.["data-disabled"]
 
   if (href) {
     return (

--- a/packages/design-systems/src/components/Button.tsx
+++ b/packages/design-systems/src/components/Button.tsx
@@ -17,7 +17,6 @@ type ButtonContentProps = {
   leftIcon?: ReactElement;
   rightIcon?: ReactElement;
   href?: string;
-  "data-disabled"?: string;
 };
 
 export type ButtonProps = ButtonVariantProps &
@@ -28,7 +27,6 @@ export type ButtonProps = ButtonVariantProps &
 
 export const Button = (props: ButtonProps) => {
   const { variant, href, size, leftIcon, rightIcon, children, ...rest } = props;
-  delete rest?.["data-disabled"];
 
   if (href) {
     return (

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -287,8 +287,6 @@ export const DataGrid = <TData extends Record<string, unknown>>({
                     variant="secondary"
                     size="md"
                     onClick={() => {
-                      console.log("next");
-                      console.log(pages);
                       table.nextPage();
                     }}
                     disabled={!table.getCanNextPage()}

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -287,9 +287,10 @@ export const DataGrid = <TData extends Record<string, unknown>>({
                     variant="secondary"
                     size="md"
                     onClick={() => {
-                      console.log("next")
-                      console.log(pages)
-                      table.nextPage()}}
+                      console.log("next");
+                      console.log(pages);
+                      table.nextPage();
+                    }}
                     disabled={!table.getCanNextPage()}
                   >
                     Next

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -244,23 +244,17 @@ export const DataGrid = <TData extends Record<string, unknown>>({
           count={table.totalCount || 0}
           pageSize={table.initialState.pagination.pageSize}
           siblingCount={2}
-          onPageChange={(details) => {
-            if (table?.getState && table?.handlePageChange) {
-              const state = table.getState();
-              if (state.pagination) {
-                table.handlePageChange({
-                  page: details.page,
-                  pageSize: details.pageSize,
-                });
-              }
-            }
-          }}
         >
           {({ pages }) => (
             <>
               <HStack gap={1}>
                 <Pagination.PrevTrigger asChild>
-                  <Button variant="secondary" size="md">
+                  <Button
+                    variant="secondary"
+                    size="md"
+                    onClick={() => table.previousPage()}
+                    disabled={!table.getCanPreviousPage()}
+                  >
                     Previous
                   </Button>
                 </Pagination.PrevTrigger>
@@ -289,7 +283,15 @@ export const DataGrid = <TData extends Record<string, unknown>>({
                 )}
 
                 <Pagination.NextTrigger asChild>
-                  <Button variant="secondary" size="md">
+                  <Button
+                    variant="secondary"
+                    size="md"
+                    onClick={() => {
+                      console.log("next")
+                      console.log(pages)
+                      table.nextPage()}}
+                    disabled={!table.getCanNextPage()}
+                  >
                     Next
                   </Button>
                 </Pagination.NextTrigger>

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import {
   ColumnPinningState,
   getCoreRowModel,
+  getPaginationRowModel,
   useReactTable,
 } from "@tanstack/react-table";
 import { Checkbox } from "../../Checkbox";
@@ -76,6 +77,9 @@ export const useDataGrid = <TData extends RowLike>({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: enablePagination
+      ? getPaginationRowModel()
+      : undefined,
     initialState,
     enableRowSelection,
     onRowSelectionChange: enableRowSelection ? onRowSelectionChange : undefined,

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -28,7 +28,7 @@ export const useDataGrid = <TData extends RowLike>({
   onRowSelectionChange,
   rowSelection,
 }: UseDataGridProps<TData>): DataGridInstance<TData> => {
-  const { pageIndex = 0, pageSize = 10 } = pagination || {};
+  const { pageIndex = 0, pageSize = 50 } = pagination || {};
   const [columnPinningState, setColumnPinningState] =
     useState<ColumnPinningState>({
       left: ["select", ...(columnPinning?.left || [])],


### PR DESCRIPTION
# Background

pagination wasn't working

# Changes

- add pagination
- data-disabled no longer functional because data-disabled is always passed to the button under prevtrigger

This pull request primarily focuses on improving the DataGrid component in the design systems package and creating new Storybook stories for the DataGrid with pagination. The changes also include a version bump for the design systems package and a minor update to the Button component. 

Storybook stories creation:

* [`apps/storybook/src/stories/datagrid/DataGridPagination.stories.tsx`](diffhunk://#diff-2aab47129b9d28406edf3712b2b9ba3fa98ce2e94a86993edbaff7af9356c5dfR1-R41): A new Storybook story was created for the DataGrid with pagination. This story demonstrates how the DataGrid component behaves with pagination enabled.
* [`apps/storybook/src/stories/datagrid/DataGridPaginationStory.tsx`](diffhunk://#diff-dab46e6b9d0a77b4b596ff46afd1a2dc0112b9f7171070e45fc3c94bc8d7dd92R1-R37): This file defines the DataGrid with pagination for the Storybook story. It sets up a DataGrid with pagination and a specified page size.

Design systems package updates:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the design systems package was bumped from 0.19.6 to 0.19.7.
* [`packages/design-systems/src/components/Button.tsx`](diffhunk://#diff-a02e656881a9d31f7e4c5a3bd6318bd9a172562f20462429366dfb6aab2ae2d1R20): A new optional property `data-disabled` was added to the `ButtonContentProps` type. This property was also removed from the rest properties in the `Button` component to prevent it from being passed down to the underlying DOM element. [[1]](diffhunk://#diff-a02e656881a9d31f7e4c5a3bd6318bd9a172562f20462429366dfb6aab2ae2d1R20) [[2]](diffhunk://#diff-a02e656881a9d31f7e4c5a3bd6318bd9a172562f20462429366dfb6aab2ae2d1R31)
* [`packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx`](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL247-R257): The `DataGrid` component was updated to handle page changes in the pagination component. The previous and next buttons now correctly move to the previous and next pages, respectively. [[1]](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL247-R257) [[2]](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL292-R295)
* [`packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx`](diffhunk://#diff-14aa5328e3b002bc6281f392fbba405593aa8ee29bc6f844d5f2c1191cefc377R5): The `useDataGrid` hook now includes the `getPaginationRowModel` function from the `@tanstack/react-table` package when pagination is enabled. [[1]](diffhunk://#diff-14aa5328e3b002bc6281f392fbba405593aa8ee29bc6f844d5f2c1191cefc377R5) [[2]](diffhunk://#diff-14aa5328e3b002bc6281f392fbba405593aa8ee29bc6f844d5f2c1191cefc377R80-R82)
