### PR TITLE
feat(ds): export type

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/client.tsx
+++ b/packages/design-systems/src/client.tsx
@@ -13,6 +13,7 @@ export {
   type DataGridInstance,
   type UseDataGridProps,
   type Localization,
+  type GraphQLQueryFilter,
   useDataGrid,
 } from "@components/composite/Datagrid";
 export {

--- a/packages/design-systems/src/components/composite/Datagrid/index.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/index.tsx
@@ -1,4 +1,8 @@
 export { DataGrid } from "./Datagrid";
 export { useDataGrid } from "./useDataGrid";
-export type { DataGridInstance, UseDataGridProps } from "./types";
+export type {
+  DataGridInstance,
+  UseDataGridProps,
+  GraphQLQueryFilter,
+} from "./types";
 export type { Localization } from "../../../locales/types";


### PR DESCRIPTION
# Background

<!-- Why is this change necessary, how it came to be? -->

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request mainly focuses on updates to the `packages/design-systems` package, specifically regarding the `Datagrid` component. The changes involve the addition of a new type, `GraphQLQueryFilter`, to the exports in `Datagrid/index.tsx` and `client.tsx`.

Here are the key changes:

* [`packages/design-systems/src/components/composite/Datagrid/index.tsx`](diffhunk://#diff-2985af77398488ba7f0f97978420b448b0f804f2fb5ca4322deadb097a4e016eL3-R7): The `GraphQLQueryFilter` type has been added to the list of exports from `./types`. This type is now available for use elsewhere in the application.
* [`packages/design-systems/src/client.tsx`](diffhunk://#diff-2ab0ae27fdfd99fcb0a73b0e6a187306667ec4499dc00612c7051ec7dde6de4cR16): The `GraphQLQueryFilter` type has been added to the list of exports from `@components/composite/Datagrid`. This allows for the type to be imported from the `design-systems` package.
