### PR TITLE
fix(ds): fix filter operator in dataGrid

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.19.8",
+  "version": "0.19.9",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/data/filter.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/data/filter.ts
@@ -36,12 +36,6 @@ export const getLocalizedFilterConditions = (
       disabled: false,
     },
     {
-      label: localization.filter.condition.operatorLabel.notInclude,
-      value: GraphQLFilterOperator.NOT_LIKE,
-      applicableTypeTypes: [],
-      disabled: false,
-    },
-    {
       label: localization.filter.condition.operatorLabel.greaterThan,
       value: GraphQLFilterOperator.GREATER_THAN,
       applicableTypeTypes: ["time", "dateTime", "date", "number"],

--- a/packages/design-systems/src/components/composite/Datagrid/data/filter.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/data/filter.ts
@@ -31,7 +31,7 @@ export const getLocalizedFilterConditions = (
     },
     {
       label: localization.filter.condition.operatorLabel.include,
-      value: GraphQLFilterOperator.LIKE,
+      value: GraphQLFilterOperator.CONTAINS,
       applicableTypeTypes: ["string"],
       disabled: false,
     },

--- a/packages/design-systems/src/components/composite/Datagrid/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/types.ts
@@ -115,7 +115,7 @@ export const GraphQLFilterOperator = {
   LESS_THAN_OR_EQUAL: "lte",
   GREATER_THAN_OR_EQUAL: "gte",
   NOT_EQUAL: "neq",
-  LIKE: "like",
+  CONTAINS: "contains",
   NOT_LIKE: "nlike",
 } as const;
 export type FilterCondition = {

--- a/packages/design-systems/src/components/composite/Datagrid/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/types.ts
@@ -116,7 +116,6 @@ export const GraphQLFilterOperator = {
   GREATER_THAN_OR_EQUAL: "gte",
   NOT_EQUAL: "neq",
   CONTAINS: "contains",
-  NOT_LIKE: "nlike",
 } as const;
 export type FilterCondition = {
   label: string;


### PR DESCRIPTION
# Background

<!-- Why is this change necessary, how it came to be? -->

A like statement is used in graphql's filter operator, but this does not actually work. contains statement is correct.


# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->

Changed "like" operator to "contains" operator
removed the "like" operator as filter doesn't use it
