### PR TITLE
fix(auth): error handling in useCurrentUser

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.0",
+  "version": "0.6.1-preview.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/src/client/hooks.test.tsx
+++ b/packages/auth/src/client/hooks.test.tsx
@@ -71,9 +71,9 @@ describe("usePlatform", () => {
         wrapper: mockProvider,
       });
 
-      await waitFor(() => {
-        expect(result.current.getCurrentUser()).toHaveProperty("sub");
-      });
+      const r = await waitFor(() => result.current.getCurrentUser());
+      expect(r.data).toHaveProperty("sub");
+      expect(r.error).toBeNull();
     });
   });
 });

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -88,7 +88,10 @@ export const useAuth = () => {
 export const usePlatform = () => {
   const config = useTailorAuth();
   const getCurrentUser = () => {
-    return internalUserinfoLoader.getSuspense(config);
+    const result = internalUserinfoLoader.getSuspense(config);
+    return "error" in result
+      ? { data: null, error: result.error }
+      : { data: result, error: null };
   };
 
   return {

--- a/packages/auth/src/core/loader.ts
+++ b/packages/auth/src/core/loader.ts
@@ -38,13 +38,16 @@ export const internalClientSessionLoader = new SingletonLoader<SessionResult>(
   (config) => fetch(config.appUrl(internalClientSessionPath)),
 );
 
-export const internalUserinfoLoader = new SingletonLoader<{
-  sub: string;
-  name: string;
-  given_name: string;
-  family_name: string;
-  email: string;
-}>(async (config) => {
+export const internalUserinfoLoader = new SingletonLoader<
+  | {
+      sub: string;
+      name: string;
+      given_name: string;
+      family_name: string;
+      email: string;
+    }
+  | { error: string }
+>(async (config) => {
   const session = await internalClientSessionLoader.load(config);
   return await fetch(config.apiUrl(config.userInfoPath()), {
     headers: {


### PR DESCRIPTION
# Background

`getCurrentUser` function lacks enough error handling

# Changes

This pull request primarily focuses on improving the error handling in the authentication package of the application. The key changes include an update to the version of the `@tailor-platform/auth` package, modifications in the `usePlatform` hook, and changes in the `internalUserinfoLoader` SingletonLoader.

Here are the most significant changes:

Package Version Update:

* [`packages/auth/package.json`](diffhunk://#diff-79fbe1d958aec3ec2b3d46cdc5b9b34cd834f48550895ce9484f10c0f77a4a8fL3-R3): The version of `@tailor-platform/auth` has been updated from `0.6.0` to `0.6.1-preview.0` to reflect the new changes.

Error Handling Improvements:

* [`packages/auth/src/client/hooks.ts`](diffhunk://#diff-1dfa41d6294f9c71b94051574daaf578d5b857d293c03c4f18553b3a8059f32aL91-R94): The `usePlatform` hook now returns an object containing either the user data or an error, instead of just the user data. This change improves error handling by making it more explicit.
* [`packages/auth/src/core/loader.ts`](diffhunk://#diff-8e986a4db2b146cea53c824b12f69e31b0f0e89605dc28a4c5bf8a7b70a09fd9L41-R50): The `internalUserinfoLoader` SingletonLoader now can load either user data or an error. This change aligns with the modification in the `usePlatform` hook.

Test Update:

* [`packages/auth/src/client/hooks.test.tsx`](diffhunk://#diff-14dda08b1f46c69de796284f6b62e52ef480ff0ff760d479d87830bf812b3c47L74-R76): The test for the `usePlatform` hook has been updated to reflect the changes in the hook's return value. The test now checks both the data and the error in the return value.
