### PR TITLE
fix(auth): fix promise handling in SingletonLoader

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -102,7 +102,7 @@ export default middleware;
 
 ### `useSession` hook
 
-A hook to get token in client components.
+A suspense hook to get token in client components.
 
 ```tsx
 "use client";
@@ -184,7 +184,7 @@ const Component = async () => {
 
 The hook that provides utility functions for Tailor Platform specific operation. It includes:
 
-- `getCurrentUser`: A function to retrieve the logged-in user's information using a valid session token.
+- `getCurrentUser`: A suspense function to retrieve the logged-in user's information.
 
 Here is an example of how to use these functions:
 
@@ -193,10 +193,9 @@ Here is an example of how to use these functions:
 import { usePlatform } from "@tailor-platform/auth/client";
 
 const Component = async () => {
-  const { token } = useSession();
   const { getCurrentUser } = usePlatform();
 
-  const user = await getCurrentUser(token);
+  const user = getCurrentUser();
 
   // utilize session and user data...
 };

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.1-preview.1",
+  "version": "0.6.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.0",
+  "version": "0.6.1-preview.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.1-preview.0",
+  "version": "0.6.1-preview.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/src/client/hooks.test.tsx
+++ b/packages/auth/src/client/hooks.test.tsx
@@ -71,9 +71,9 @@ describe("usePlatform", () => {
         wrapper: mockProvider,
       });
 
-      await waitFor(() => {
-        expect(result.current.getCurrentUser()).toHaveProperty("sub");
-      });
+      const r = await waitFor(() => result.current.getCurrentUser());
+      expect(r.data).toHaveProperty("sub");
+      expect(r.error).toBeNull();
     });
   });
 });

--- a/packages/auth/src/client/hooks.test.tsx
+++ b/packages/auth/src/client/hooks.test.tsx
@@ -72,8 +72,7 @@ describe("usePlatform", () => {
       });
 
       const r = await waitFor(() => result.current.getCurrentUser());
-      expect(r.data).toHaveProperty("sub");
-      expect(r.error).toBeNull();
+      expect(r).toHaveProperty("sub");
     });
   });
 });

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -87,15 +87,9 @@ export const useAuth = () => {
 // usePlatform is a hook that contains Tailor Platform specific functions
 export const usePlatform = () => {
   const config = useTailorAuth();
-  const getCurrentUser = () => {
-    const result = internalUserinfoLoader.getSuspense(config);
-    return "error" in result
-      ? { data: null, error: result.error }
-      : { data: result, error: null };
-  };
 
   return {
-    getCurrentUser,
+    getCurrentUser: () => internalUserinfoLoader.getSuspense(config),
   };
 };
 

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -88,7 +88,10 @@ export const useAuth = () => {
 export const usePlatform = () => {
   const config = useTailorAuth();
   const getCurrentUser = () => {
-    return internalUserinfoLoader.getSuspense(config);
+    const result = internalUserinfoLoader.getSuspense(config);
+    return "error" in result
+      ? { data: null, error: result.error }
+      : { data: result, error: null };
   };
 
   return {

--- a/packages/auth/src/core/loader.ts
+++ b/packages/auth/src/core/loader.ts
@@ -38,13 +38,16 @@ export const internalClientSessionLoader = new SingletonLoader<SessionResult>(
   (config) => fetch(config.appUrl(internalClientSessionPath)),
 );
 
-export const internalUserinfoLoader = new SingletonLoader<{
-  sub: string;
-  name: string;
-  given_name: string;
-  family_name: string;
-  email: string;
-}>(async (config) => {
+export const internalUserinfoLoader = new SingletonLoader<
+  | {
+      sub: string;
+      name: string;
+      given_name: string;
+      family_name: string;
+      email: string;
+    }
+  | { error: string }
+>(async (config) => {
   const session = await internalClientSessionLoader.load(config);
   return await fetch(config.apiUrl(config.userInfoPath()), {
     headers: {

--- a/packages/auth/src/core/loader.ts
+++ b/packages/auth/src/core/loader.ts
@@ -6,15 +6,24 @@ import { SessionResult } from "@core/types";
 // and caches the result for React Suspense support in client components.
 class SingletonLoader<R> {
   private value: R | null;
+  private error: Error | null;
 
   constructor(private readonly loader: (config: Config) => Promise<Response>) {
     this.value = null;
+    this.error = null;
   }
 
   async load(config: Config) {
-    const resp = await this.loader(config);
-    this.value = (await resp.json()) as unknown as R;
-    return this.value;
+    return this.loader(config)
+      .then(async (resp) => {
+        this.value = (await resp.json()) as unknown as R;
+      })
+      .catch((error) => {
+        if (error instanceof Error) {
+          this.error = error;
+          throw error;
+        }
+      });
   }
 
   get() {
@@ -22,36 +31,41 @@ class SingletonLoader<R> {
   }
 
   getSuspense(config: Config) {
-    if (!this.value) {
+    if (this.error) {
+      throw this.error;
+    } else if (!this.value) {
       throw this.load(config);
+    } else {
+      return this.value;
     }
-    return this.value;
   }
 
   // Clear stored value (this is only for test usage)
   clear() {
     this.value = null;
+    this.error = null;
   }
 }
 
+const fetchSession = async (config: Config) =>
+  fetch(config.appUrl(internalClientSessionPath));
+
 export const internalClientSessionLoader = new SingletonLoader<SessionResult>(
-  (config) => fetch(config.appUrl(internalClientSessionPath)),
+  fetchSession,
 );
 
-export const internalUserinfoLoader = new SingletonLoader<
-  | {
-      sub: string;
-      name: string;
-      given_name: string;
-      family_name: string;
-      email: string;
-    }
-  | { error: string }
->(async (config) => {
-  const session = await internalClientSessionLoader.load(config);
+export const internalUserinfoLoader = new SingletonLoader<{
+  sub: string;
+  name: string;
+  given_name: string;
+  family_name: string;
+  email: string;
+}>(async (config) => {
+  const resp = await fetchSession(config);
+  const session = (await resp.json()) as unknown as SessionResult;
   return await fetch(config.apiUrl(config.userInfoPath()), {
     headers: {
-      Authorization: `Bearer ${session?.token}`,
+      Authorization: `Bearer ${session.token}`,
     },
   });
 });


### PR DESCRIPTION
# Background

Stumbled upon that the new design made in #143 led to the new bug that prevents auth package from working properly only on Next.js production build.

# Changes

This pull request primarily focuses on improving the `packages/auth` package. The main changes revolve around the handling of user sessions and error management in the `SingletonLoader` class. The `usePlatform` hook and associated tests have also been slightly refactored for better readability. Lastly, the version of the `@tailor-platform/auth` package has been updated.

User Session Handling:

* [`packages/auth/src/core/loader.ts`](diffhunk://#diff-8e986a4db2b146cea53c824b12f69e31b0f0e89605dc28a4c5bf8a7b70a09fd9R9-R54): The `SingletonLoader` class now includes error management. An error property has been added to the class, and the `load` method has been updated to catch and store any errors that occur during the loading process. The `getSuspense` method has been updated to throw any stored error before attempting to load the configuration, improving error handling.
* [`packages/auth/src/core/loader.ts`](diffhunk://#diff-8e986a4db2b146cea53c824b12f69e31b0f0e89605dc28a4c5bf8a7b70a09fd9L48-R68): The `internalUserinfoLoader` now directly calls `fetchSession` to get the session data, and the `Authorization` header in the fetch call no longer checks for the existence of the session token, simplifying the code.

Hook Refactoring:

* [`packages/auth/src/client/hooks.ts`](diffhunk://#diff-1dfa41d6294f9c71b94051574daaf578d5b857d293c03c4f18553b3a8059f32aL90-R92): The `getCurrentUser` function within the `usePlatform` hook has been simplified to a single line, improving readability.
* [`packages/auth/src/client/hooks.test.tsx`](diffhunk://#diff-14dda08b1f46c69de796284f6b62e52ef480ff0ff760d479d87830bf812b3c47L74-R75): The test for the `usePlatform` hook has been refactored to improve readability and maintainability. The `waitFor` function now directly returns the result of `getCurrentUser`, which is then checked to have the `sub` property.

Package Version Update:

* [`packages/auth/package.json`](diffhunk://#diff-79fbe1d958aec3ec2b3d46cdc5b9b34cd834f48550895ce9484f10c0f77a4a8fL3-R3): The version of the `@tailor-platform/auth` package has been updated from `0.6.0` to `0.6.1-preview.1`.
