### PR TITLE
fix(ds): fix datagrid was always displayed

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -257,11 +257,12 @@ export const DataGrid = <TData extends Record<string, unknown>>({
           )}
         </TableBody>
       </Table>
-      {table.enablePagination && table.manualPagination ? (
-        <ManualPagination table={table} />
-      ) : (
-        <Pagination table={table} />
-      )}
+      {table.enablePagination &&
+        (table.manualPagination ? (
+          <ManualPagination table={table} />
+        ) : (
+          <Pagination table={table} />
+        ))}
     </Stack>
   );
 };


### PR DESCRIPTION
# Background

pagination was always displayed
<!-- Why is this change necessary, how it came to be? -->

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request primarily focuses on updates to the `packages/design-systems` package. The most significant changes include a version bump and a modification to the `DataGrid` component to improve the condition for rendering pagination.

Key changes:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the `@tailor-platform/design-systems` package has been updated from `0.20.0` to `0.20.1`. This suggests that minor updates or bug fixes have been made to the package.

* [`packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx`](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL260-R265): The condition for rendering pagination in the `DataGrid` component has been modified. Previously, pagination was rendered if `table.enablePagination` and `table.manualPagination` were both true. Now, pagination will be rendered if `table.enablePagination` is true, regardless of the value of `table.manualPagination`. This change makes the component more flexible by allowing automatic pagination when manual pagination is not enabled.