### PR TITLE
fix(ds): fix last page in manual pagination

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
@@ -33,7 +33,7 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
     pageIndex: 0,
     pageSize: table.initialState.pagination.pageSize,
   });
-  const { from, to, pages, isNextPage } = usePagination(
+  const { from, to, pages, pageCount, isNextPage } = usePagination(
     table,
     pageIndex,
     pageSize,
@@ -167,8 +167,8 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
           variant="secondary"
           aria-label="Last Page"
           onClick={() => {
-            setPagination({ pageIndex: table.getPageCount() - 1, pageSize });
-            handlePageChange({ page: table.getPageCount() - 1, pageSize });
+            setPagination({ pageIndex: pageCount - 1, pageSize });
+            handlePageChange({ page: pageCount - 1, pageSize });
           }}
           disabled={isNextPage}
         >

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/utils.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/utils.ts
@@ -14,10 +14,11 @@ export const usePagination = <TData extends Record<string, unknown>>(
 ) => {
   const from = useMemo(() => pageIndex * pageSize + 1, [pageIndex, pageSize]);
   const to = useMemo(() => from + pageSize - 1, [from, pageSize]);
+  const pageCount = useMemo(
+    () => (table.totalCount ? Math.ceil(table.totalCount / pageSize) : 0),
+    [table, pageSize],
+  );
   const pages: Page[] = useMemo(() => {
-    const pageCount = table.totalCount
-      ? Math.ceil(table.totalCount / pageSize)
-      : 0;
     const pageList = [...Array(pageCount).keys()];
     return pageList
       .filter((i) => Math.abs(i - pageIndex) < ELLIPSIS_SIZE + 1)
@@ -27,15 +28,12 @@ export const usePagination = <TData extends Record<string, unknown>>(
           type: Math.abs(p - pageIndex) === ELLIPSIS_SIZE ? "ellipsis" : "page",
         };
       });
-  }, [table, pageIndex, pageSize]);
+  }, [pageIndex, pageCount]);
   const isNextPage = useMemo(() => {
-    const pageCount = table.totalCount
-      ? Math.ceil(table.totalCount / pageSize)
-      : 0;
     return pageIndex === pageCount - 1;
-  }, [pageIndex, pageSize, table]);
+  }, [pageIndex, pageCount]);
 
-  return { from, to, pages, isNextPage };
+  return { from, to, pages, pageCount, isNextPage };
 };
 
 export const Select = {


### PR DESCRIPTION
# Background

A bug occurs when the go to last page function in manual pagination changes the page size

<!-- Why is this change necessary, how it came to be? -->

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request mainly focuses on updating the pagination functionality in the design systems package, and also includes a minor version update to the package. The changes improve the efficiency of the pagination system by reducing the number of times the page count is calculated and simplifying the dependencies of the `useMemo` hooks in the `usePagination` utility.

Here are the key changes:

**Version update:**

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The package version was incremented from 0.20.1 to 0.20.2.

**Pagination improvements:**

* [`packages/design-systems/src/components/composite/Datagrid/Pagination/utils.ts`](diffhunk://#diff-a241ae1321b8e7147f2898c60b269df394b62d2138c6146f5dde9d9801335786R17-L20): The `pageCount` is now calculated once and returned as part of the `usePagination` hook's return value, reducing the number of times this calculation is performed. The dependencies of the `useMemo` hooks were also updated to reflect this change. [[1]](diffhunk://#diff-a241ae1321b8e7147f2898c60b269df394b62d2138c6146f5dde9d9801335786R17-L20) [[2]](diffhunk://#diff-a241ae1321b8e7147f2898c60b269df394b62d2138c6146f5dde9d9801335786L30-R36)
* [`packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx`](diffhunk://#diff-b18e0964543b2ec2d14856c16e5fdcd91ac494a6516b1f6bacd68b4a039cf154L36-R36): The `ManualPagination` component now uses the `pageCount` value returned from `usePagination`, instead of calculating the page count itself. [[1]](diffhunk://#diff-b18e0964543b2ec2d14856c16e5fdcd91ac494a6516b1f6bacd68b4a039cf154L36-R36) [[2]](diffhunk://#diff-b18e0964543b2ec2d14856c16e5fdcd91ac494a6516b1f6bacd68b4a039cf154L170-R171)