### PR TITLE
feat(ds): localized pagination

### DIFF
--- a/apps/storybook/src/stories/datagrid/DataGridMultilingualStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridMultilingualStory.tsx
@@ -29,8 +29,14 @@ export const DataGridMultilingualStory = ({
     data,
     columns,
     enableColumnFilters,
+    enablePagination: true,
     onFilterChange: (filter) => {
       setFilterChange(filter, originData, setData);
+    },
+    totalCount: 14,
+    pagination: {
+      pageIndex: 0,
+      pageSize: 5,
     },
     localization: localization === "JA" ? LOCALIZATION_JA : LOCALIZATION_EN,
   });

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -264,9 +264,9 @@ export const DataGrid = <TData extends Record<string, unknown>>({
       </Table>
       {table.enablePagination &&
         (table.manualPagination ? (
-          <ManualPagination table={table} />
+          <ManualPagination table={table} localization={localization} />
         ) : (
-          <Pagination table={table} />
+          <Pagination table={table} localization={localization} />
         ))}
     </Stack>
   );

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
@@ -21,13 +21,16 @@ import { Text } from "../../../Text";
 import { Button } from "../../../Button";
 import { IconButton } from "../../../IconButton";
 import { selectList, Select, usePagination } from "./utils";
+import { Localization } from "@locales/types";
 
 const classes = select();
 
 export const ManualPagination = <TData extends Record<string, unknown>>({
   table,
+  localization,
 }: {
   table: DataGridInstance<TData>;
+  localization: Localization;
 }) => {
   const [{ pageIndex, pageSize }, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -45,7 +48,7 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
   return (
     <HStack justifyContent={"flex-end"} gap={8}>
       <HStack>
-        <Text>ページあたり行数</Text>
+        <Text>{localization.pagination.rowsPerPage}</Text>
         <Select.Root
           className={classes.root}
           items={selectList}
@@ -98,13 +101,30 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
         </Select.Root>
       </HStack>
       <HStack gap={2}>
-        <Text fontWeight={"bold"}>{table.getRowCount()}</Text>
-        件中
-        <Text fontWeight={"bold"}>
-          {from}-
-          {table.totalCount && to > table.totalCount ? table.totalCount : to}
-        </Text>
-        件
+        {localization.pagination.of === "of" ? (
+          <>
+            <Text fontWeight={"bold"}>
+              {from}-
+              {table.totalCount && to > table.totalCount
+                ? table.totalCount
+                : to}
+            </Text>
+            {localization.pagination.of}
+            <Text fontWeight={"bold"}>{table.getRowCount()}</Text>
+          </>
+        ) : (
+          <>
+            <Text fontWeight={"bold"}>{table.getRowCount()}</Text>
+            {localization.pagination.of}
+            <Text fontWeight={"bold"}>
+              {from}-
+              {table.totalCount && to > table.totalCount
+                ? table.totalCount
+                : to}
+            </Text>
+            {localization.pagination.page}
+          </>
+        )}
       </HStack>
       <HStack>
         <IconButton

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
@@ -101,18 +101,7 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
         </Select.Root>
       </HStack>
       <HStack gap={2}>
-        {localization.pagination.of === "of" ? (
-          <>
-            <Text fontWeight={"bold"}>
-              {from}-
-              {table.totalCount && to > table.totalCount
-                ? table.totalCount
-                : to}
-            </Text>
-            {localization.pagination.of}
-            <Text fontWeight={"bold"}>{table.getRowCount()}</Text>
-          </>
-        ) : (
+        {localization.language === "JA" ? (
           <>
             <Text fontWeight={"bold"}>{table.getRowCount()}</Text>
             {localization.pagination.of}
@@ -123,6 +112,17 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
                 : to}
             </Text>
             {localization.pagination.page}
+          </>
+        ) : (
+          <>
+            <Text fontWeight={"bold"}>
+              {from}-
+              {table.totalCount && to > table.totalCount
+                ? table.totalCount
+                : to}
+            </Text>
+            {localization.pagination.of}
+            <Text fontWeight={"bold"}>{table.getRowCount()}</Text>
           </>
         )}
       </HStack>

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
@@ -16,13 +16,16 @@ import { Text } from "../../../Text";
 import { Button } from "../../../Button";
 import { IconButton } from "../../../IconButton";
 import { selectList, Select, usePagination } from "./utils";
+import { Localization } from "@locales/types";
 
 const classes = select();
 
 export const Pagination = <TData extends Record<string, unknown>>({
   table,
+  localization,
 }: {
   table: DataGridInstance<TData>;
+  localization: Localization;
 }) => {
   const pageIndex = useMemo(
     () => table.getState().pagination.pageIndex,
@@ -34,7 +37,7 @@ export const Pagination = <TData extends Record<string, unknown>>({
   return (
     <HStack justifyContent={"flex-end"} gap={8}>
       <HStack>
-        <Text>ページあたり行数</Text>
+        <Text>{localization.pagination.rowsPerPage}</Text>
         <Select.Root
           className={classes.root}
           items={selectList}
@@ -86,13 +89,30 @@ export const Pagination = <TData extends Record<string, unknown>>({
         </Select.Root>
       </HStack>
       <HStack gap={2}>
-        <Text fontWeight={"bold"}>{table.getRowCount()}</Text>
-        件中
-        <Text fontWeight={"bold"}>
-          {from}-
-          {table.totalCount && to > table.totalCount ? table.totalCount : to}
-        </Text>
-        件
+        {localization.pagination.of === "of" ? (
+          <>
+            <Text fontWeight={"bold"}>
+              {from}-
+              {table.totalCount && to > table.totalCount
+                ? table.totalCount
+                : to}
+            </Text>
+            {localization.pagination.of}
+            <Text fontWeight={"bold"}>{table.getRowCount()}</Text>
+          </>
+        ) : (
+          <>
+            <Text fontWeight={"bold"}>{table.getRowCount()}</Text>
+            {localization.pagination.of}
+            <Text fontWeight={"bold"}>
+              {from}-
+              {table.totalCount && to > table.totalCount
+                ? table.totalCount
+                : to}
+            </Text>
+            {localization.pagination.page}
+          </>
+        )}
       </HStack>
       <HStack>
         <IconButton

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
@@ -89,18 +89,7 @@ export const Pagination = <TData extends Record<string, unknown>>({
         </Select.Root>
       </HStack>
       <HStack gap={2}>
-        {localization.pagination.of === "of" ? (
-          <>
-            <Text fontWeight={"bold"}>
-              {from}-
-              {table.totalCount && to > table.totalCount
-                ? table.totalCount
-                : to}
-            </Text>
-            {localization.pagination.of}
-            <Text fontWeight={"bold"}>{table.getRowCount()}</Text>
-          </>
-        ) : (
+        {localization.language === "JA" ? (
           <>
             <Text fontWeight={"bold"}>{table.getRowCount()}</Text>
             {localization.pagination.of}
@@ -111,6 +100,17 @@ export const Pagination = <TData extends Record<string, unknown>>({
                 : to}
             </Text>
             {localization.pagination.page}
+          </>
+        ) : (
+          <>
+            <Text fontWeight={"bold"}>
+              {from}-
+              {table.totalCount && to > table.totalCount
+                ? table.totalCount
+                : to}
+            </Text>
+            {localization.pagination.of}
+            <Text fontWeight={"bold"}>{table.getRowCount()}</Text>
           </>
         )}
       </HStack>

--- a/packages/design-systems/src/locales/en.ts
+++ b/packages/design-systems/src/locales/en.ts
@@ -40,4 +40,9 @@ export const LOCALIZATION_EN: Localization = {
     valuePlaceholderEnum: "Select Value",
     validationErrorDate: "Invalid Date",
   },
+  pagination: {
+    rowsPerPage: "Rows per page:",
+    of: "of",
+    page: "",
+  },
 };

--- a/packages/design-systems/src/locales/en.ts
+++ b/packages/design-systems/src/locales/en.ts
@@ -3,6 +3,7 @@ import { Localization } from "./types";
  * English localization
  */
 export const LOCALIZATION_EN: Localization = {
+  language: "EN",
   columnFeatures: {
     hideShow: {
       showAll: "Show All",

--- a/packages/design-systems/src/locales/ja.ts
+++ b/packages/design-systems/src/locales/ja.ts
@@ -3,6 +3,7 @@ import { Localization } from "./types";
  * Japanese localization
  */
 export const LOCALIZATION_JA: Localization = {
+  language: "JA",
   columnFeatures: {
     hideShow: {
       showAll: "全て表示",

--- a/packages/design-systems/src/locales/ja.ts
+++ b/packages/design-systems/src/locales/ja.ts
@@ -40,4 +40,9 @@ export const LOCALIZATION_JA: Localization = {
     valuePlaceholderEnum: "値を選択",
     validationErrorDate: "日付が不正です",
   },
+  pagination: {
+    rowsPerPage: "ぺージあたりの行数",
+    of: "件中",
+    page: "件",
+  },
 };

--- a/packages/design-systems/src/locales/types.ts
+++ b/packages/design-systems/src/locales/types.ts
@@ -36,4 +36,9 @@ export interface Localization {
       unPin: string;
     };
   };
+  pagination: {
+    rowsPerPage: string;
+    of: string;
+    page: string;
+  };
 }

--- a/packages/design-systems/src/locales/types.ts
+++ b/packages/design-systems/src/locales/types.ts
@@ -1,4 +1,5 @@
 export interface Localization {
+  language: "JA" | "EN";
   filter: {
     filterLabel: string;
     filterResetLabel: string;

--- a/packages/design-systems/src/locales/types.ts
+++ b/packages/design-systems/src/locales/types.ts
@@ -1,5 +1,5 @@
 export interface Localization {
-  language: "JA" | "EN";
+  language: string;
   filter: {
     filterLabel: string;
     filterResetLabel: string;


### PR DESCRIPTION
# Background

Pagination is not localized
<!-- Why is this change necessary, how it came to be? -->

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request primarily focuses on enhancing the localization and pagination features of the `DataGrid` component in the `design-systems` package. The changes include the addition of a `pagination` object in the `Localization` interface, updates to the `ManualPagination` and `Pagination` components to use localization, and the addition of pagination properties in the `DataGridMultilingualStory` component. Additionally, the version of the `design-systems` package has been updated.

Localization Improvements:

* [`packages/design-systems/src/locales/types.ts`](diffhunk://#diff-23d05766725ea33f62dee80b9e86ba60c162dea3dba29691754d18caad56b073R39-R43): Added a `pagination` object in the `Localization` interface to support localized pagination text.
* `packages/design-systems/src/locales/en.ts` and `packages/design-systems/src/locales/ja.ts`: Updated the `LOCALIZATION_EN` and `LOCALIZATION_JA` objects to include localized pagination text. [[1]](diffhunk://#diff-1858a96bd5462cc084b42e493806c658aaba5221402dea60464595a3ad912410R43-R47) [[2]](diffhunk://#diff-9471627b37051b709de5d94829c2b7a5a7f93beff388d175f45f53cd71df861bR43-R47)

Pagination Enhancements:

* [`apps/storybook/src/stories/datagrid/DataGridMultilingualStory.tsx`](diffhunk://#diff-911a2e733fe52b5c2e7ef27b702ea692815c9debbba673fed11c9b2a796186a7R32-R40): Added `enablePagination`, `totalCount`, and `pagination` properties to the `DataGridMultilingualStory` component to enable and configure pagination.
* [`packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx`](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL267-R269): Updated the `DataGrid` component to pass the `localization` prop to the `ManualPagination` and `Pagination` components.
* `packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx` and `packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx`: Updated these components to use the `localization` prop for displaying localized pagination text. [[1]](diffhunk://#diff-b18e0964543b2ec2d14856c16e5fdcd91ac494a6516b1f6bacd68b4a039cf154R24-R33) [[2]](diffhunk://#diff-b18e0964543b2ec2d14856c16e5fdcd91ac494a6516b1f6bacd68b4a039cf154L48-R51) [[3]](diffhunk://#diff-b18e0964543b2ec2d14856c16e5fdcd91ac494a6516b1f6bacd68b4a039cf154R104-R127) [[4]](diffhunk://#diff-cf4ddce20ee1ffa24bf1bad804161e44abdbe499f279fe6bfba9ba369a9b9bcbR19-R28) [[5]](diffhunk://#diff-cf4ddce20ee1ffa24bf1bad804161e44abdbe499f279fe6bfba9ba369a9b9bcbL37-R40) [[6]](diffhunk://#diff-cf4ddce20ee1ffa24bf1bad804161e44abdbe499f279fe6bfba9ba369a9b9bcbR92-R115)

Package Update:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): Updated the version of the `design-systems` package from `0.20.4` to `0.20.5`.