### PR TITLE
fix(ds): fix datagrid dark theme

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/theme/slot-recipes/datagrid.ts
+++ b/packages/design-systems/src/theme/slot-recipes/datagrid.ts
@@ -14,7 +14,7 @@ export const datagrid = defineSlotRecipe({
   description: "An datagrid style",
   base: {
     table: {
-      backgroundColor: "white",
+      backgroundColor: "canvas.base",
       width: "100%",
       borderWidth: "0.5px",
       borderColor: "border.default",


### PR DESCRIPTION
# Background
<!-- Why is this change necessary, how it came to be? -->

before:

https://github.com/tailor-platform/frontend-packages/assets/17076187/3bc9d196-c111-4e77-af30-e0cd3a74c365

after:

https://github.com/tailor-platform/frontend-packages/assets/17076187/60728ea1-de15-4996-be8d-dbe38dc711c9


# Changes
<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request primarily focuses on the `packages/design-systems` module. It includes an update to the module's version number and a change in the `datagrid` slot recipe's base table background color.

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the `@tailor-platform/design-systems` module has been incremented from `0.20.6` to `0.20.7`.
* [`packages/design-systems/src/theme/slot-recipes/datagrid.ts`](diffhunk://#diff-6e7c19af9e55eb0f78020e03670f34958c831c01320af967b1456e7f2de63f1bL17-R17): The `backgroundColor` property of the `base` object in the `datagrid` slot recipe has been modified. The value has been changed from `"white"` to `"canvas.base"`, which likely refers to a variable or constant defined elsewhere in the codebase.