### PR TITLE
fix(ds): fix display collapse when totalCount is 0

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.20.7",
+  "version": "0.20.8",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/utils.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/utils.ts
@@ -12,7 +12,10 @@ export const usePagination = <TData extends Record<string, unknown>>(
   pageIndex: number,
   pageSize: number,
 ) => {
-  const from = useMemo(() => pageIndex * pageSize + 1, [pageIndex, pageSize]);
+  const from = useMemo(
+    () => (table.totalCount === 0 ? 0 : pageIndex * pageSize + 1),
+    [pageIndex, pageSize, table],
+  );
   const to = useMemo(() => from + pageSize - 1, [from, pageSize]);
   const pageCount = useMemo(
     () => (table.totalCount ? Math.ceil(table.totalCount / pageSize) : 0),

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/utils.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/utils.ts
@@ -16,7 +16,10 @@ export const usePagination = <TData extends Record<string, unknown>>(
     () => (table.totalCount === 0 ? 0 : pageIndex * pageSize + 1),
     [pageIndex, pageSize, table],
   );
-  const to = useMemo(() => from + pageSize - 1, [from, pageSize]);
+  const to = useMemo(
+    () => (from === 0 ? 0 : from + pageSize - 1),
+    [from, pageSize],
+  );
   const pageCount = useMemo(
     () => (table.totalCount ? Math.ceil(table.totalCount / pageSize) : 0),
     [table, pageSize],

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
@@ -107,785 +107,796 @@ const columns: Column<Payment>[] = [
   },
 ];
 
-describe("<CustomFilter />", () => {
-  it("Renders the component correctly when locale is set as English", () => {
-    let currentFilters: GraphQLQueryFilter = {};
-    render(
-      <CustomFilter
-        columns={columns}
-        onChange={(currentState: GraphQLQueryFilter) => {
-          currentFilters = currentState;
-        }}
-        localization={LOCALIZATION_EN}
-        isVisible={true}
-      />,
-    );
-    expect(screen.getByText("Reset Filter")).toBeVisible();
-    expect(screen.getByText("Column")).toBeVisible();
-    expect(screen.getByText("Select Column")).toBeVisible();
-    expect(screen.getByText("Condition")).toBeVisible();
-    expect(screen.getByText("Select Condition")).toBeVisible();
-    expect(screen.getByText("Value")).toBeVisible();
-    expect(screen.getByPlaceholderText("Input Value")).toBeVisible();
-    expect(
-      screen.getByRole("button", {
-        name: "Add Filter",
-      }),
-    ).toBeVisible();
-
-    //Check filters
-    expect(currentFilters).toEqual({});
-  });
-
-  it("Renders the component correctly when locale is set as Japanese", () => {
-    let currentFilters: GraphQLQueryFilter = {};
-    render(
-      <CustomFilter
-        columns={columns}
-        onChange={(currentState: GraphQLQueryFilter) => {
-          currentFilters = currentState;
-        }}
-        localization={LOCALIZATION_JA}
-        isVisible={true}
-      />,
-    );
-    expect(screen.getByText("フィルタをリセット")).toBeVisible();
-    expect(screen.getByText("列")).toBeVisible();
-    expect(screen.getByText("列を選択")).toBeVisible();
-    expect(screen.getByText("条件")).toBeVisible();
-    expect(screen.getByText("条件を選択")).toBeVisible();
-    expect(screen.getByText("値")).toBeVisible();
-    expect(screen.getByPlaceholderText("値を入力")).toBeVisible();
-    expect(
-      screen.getByRole("button", {
-        name: "条件追加",
-      }),
-    ).toBeVisible();
-
-    //Check filters
-    expect(currentFilters).toEqual({});
-  });
-
-  it("Renders ENUM type correctly", async () => {
-    let currentFilters: GraphQLQueryFilter = {};
-    render(
-      <CustomFilter
-        columns={columns}
-        onChange={(currentState: GraphQLQueryFilter) => {
-          currentFilters = currentState;
-        }}
-        localization={LOCALIZATION_JA}
-        isVisible={true}
-      />,
-    );
-
-    const user = userEvent.setup();
-
-    //Select column
-    const selectColumn = screen.getByTestId("select-column");
-    const selectColumnOptions = screen.getByTestId("select-column-options");
-    const selectColumnButton = within(selectColumn).getByRole("button");
-    await act(async () => {
-      await user.click(selectColumnButton);
-    });
-
-    const statusOption = within(selectColumnOptions).getByText("Status");
-    expect(statusOption).toBeVisible();
-
-    await act(async () => {
-      await user.click(statusOption);
-    });
-
-    expect(statusOption).not.toBeVisible();
-    expect(selectColumn).toHaveTextContent("Status");
-
-    //Select condition
-    const selectCondition = screen.getByTestId("select-condition");
-    const selectConditionOptions = screen.getByTestId(
-      "select-condition-options",
-    );
-    const selectConditionButton = within(selectCondition).getByRole("button");
-    await act(async () => {
-      await user.click(selectConditionButton);
-    });
-
-    const equalConditionOption = within(selectConditionOptions).getByText(
-      "に等しい",
-    );
-    expect(equalConditionOption).toBeVisible();
-    expect(
-      within(selectConditionOptions).getByText("に等しくない"),
-    ).toBeVisible();
-    expect(within(selectConditionOptions).queryByText("を含む")).toBeNull();
-
-    await act(async () => {
-      await user.click(equalConditionOption);
-    });
-
-    expect(equalConditionOption).not.toBeVisible();
-    expect(selectCondition).toHaveTextContent("に等しい");
-
-    //Select value
-    const selectValue = screen.getByTestId("select-input-value");
-    const selectValueOptions = screen.getByTestId("select-input-value-options");
-    const selectValueButton = within(selectValue).getByRole("button");
-    await act(async () => {
-      await user.click(selectValueButton);
-    });
-
-    const pendingValueOption = within(selectValueOptions).getByText("pending");
-    expect(pendingValueOption).toBeVisible();
-    expect(within(selectValueOptions).getByText("processing")).toBeVisible();
-    expect(within(selectValueOptions).getByText("success")).toBeVisible();
-    expect(within(selectValueOptions).getByText("failed")).toBeVisible();
-
-    await act(async () => {
-      await user.click(pendingValueOption);
-    });
-
-    expect(pendingValueOption).not.toBeVisible();
-    expect(selectValue).toHaveTextContent("pending");
-
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual({ status: { eq: "pending" } });
-    });
-  });
-
-  it("Renders string type correctly", async () => {
-    let currentFilters: GraphQLQueryFilter = {};
-
-    render(
-      <CustomFilter
-        columns={columns}
-        onChange={(currentState: GraphQLQueryFilter) => {
-          currentFilters = currentState;
-        }}
-        localization={LOCALIZATION_JA}
-        isVisible={true}
-      />,
-    );
-
-    const user = userEvent.setup();
-
-    // Select column
-    const selectColumn = screen.getByTestId("select-column");
-    const selectColumnOptions = screen.getByTestId("select-column-options");
-    const selectColumnButton = within(selectColumn).getByRole("button");
-    await act(async () => {
-      await user.click(selectColumnButton);
-    });
-
-    const emailOption = within(selectColumnOptions).getByText("Email");
-    expect(emailOption).toBeVisible();
-
-    await act(async () => {
-      await user.click(emailOption);
-    });
-
-    expect(emailOption).not.toBeVisible();
-    expect(selectColumn).toHaveTextContent("Email");
-
-    // Select condition
-    const selectCondition = screen.getByTestId("select-condition");
-    const selectConditionOptions = screen.getByTestId(
-      "select-condition-options",
-    );
-    const selectConditionButton = within(selectCondition).getByRole("button");
-    await act(async () => {
-      await user.click(selectConditionButton);
-    });
-
-    const equalConditionOption = within(selectConditionOptions).getByText(
-      "に等しい",
-    );
-    expect(equalConditionOption).toBeVisible();
-    expect(within(selectConditionOptions).getByText("を含む")).toBeVisible();
-    expect(
-      within(selectConditionOptions).queryByText("に等しくない"),
-    ).toBeNull();
-
-    await act(async () => {
-      await user.click(equalConditionOption);
-    });
-
-    expect(equalConditionOption).not.toBeVisible();
-    expect(selectCondition).toHaveTextContent("に等しい");
-
-    // Input value
-    const inputValue = screen.getByTestId("select-input-value");
-    await act(async () => {
-      await user.click(inputValue);
-      await user.type(inputValue, "test@test.com");
-    });
-
-    expect(inputValue).toHaveValue("test@test.com");
-
-    // Check filters
-    expect(currentFilters).toEqual({ email: { eq: "test@test.com" } });
-  });
-
-  it("Renders number type correctly", async () => {
-    let currentFilters: GraphQLQueryFilter = {};
-
-    render(
-      <CustomFilter
-        columns={columns}
-        onChange={(currentState: GraphQLQueryFilter) => {
-          currentFilters = currentState;
-        }}
-        localization={LOCALIZATION_JA}
-        isVisible={true}
-      />,
-    );
-
-    const user = userEvent.setup();
-
-    // Select column
-    const selectColumn = screen.getByTestId("select-column");
-    const selectColumnOptions = screen.getByTestId("select-column-options");
-    const selectColumnButton = within(selectColumn).getByRole("button");
-    await act(async () => {
-      await user.click(selectColumnButton);
-    });
-
-    const amountOption = within(selectColumnOptions).getByText("Amount");
-    expect(amountOption).toBeVisible();
-
-    await act(async () => {
-      await user.click(amountOption);
-    });
-
-    expect(amountOption).not.toBeVisible();
-    expect(selectColumn).toHaveTextContent("Amount");
-
-    // Select condition
-    const selectCondition = screen.getByTestId("select-condition");
-    const selectConditionOptions = screen.getByTestId(
-      "select-condition-options",
-    );
-    const selectConditionButton = within(selectCondition).getByRole("button");
-    await act(async () => {
-      await user.click(selectConditionButton);
-    });
-
-    const equalConditionOption = within(selectConditionOptions).getByText(
-      "に等しい",
-    );
-    expect(equalConditionOption).toBeVisible();
-    expect(
-      within(selectConditionOptions).getByText("より大きい"),
-    ).toBeVisible();
-    expect(
-      within(selectConditionOptions).getByText("より小さい"),
-    ).toBeVisible();
-    expect(within(selectConditionOptions).getByText("以上")).toBeVisible();
-    expect(within(selectConditionOptions).getByText("以下")).toBeVisible();
-
-    expect(within(selectConditionOptions).queryByText("を含む")).toBeNull();
-
-    await act(async () => {
-      await user.click(equalConditionOption);
-    });
-
-    expect(equalConditionOption).not.toBeVisible();
-    expect(selectCondition).toHaveTextContent("に等しい");
-
-    // Input value
-    const inputValue = await screen.findByTestId("select-input-value");
-    await act(async () => {
-      fireEvent.change(inputValue, { target: { value: "800" } });
-    });
-
-    expect(inputValue).toHaveValue(800);
-
-    // Check filters
-    expect(currentFilters).toEqual({ amount: { eq: "800" } });
-  });
-
-  it("Renders Date type correctly", async () => {
-    let currentFilters: GraphQLQueryFilter = {};
-
-    render(
-      <CustomFilter
-        columns={columns}
-        onChange={(currentState: GraphQLQueryFilter) => {
-          currentFilters = currentState;
-        }}
-        localization={LOCALIZATION_JA}
-        isVisible={true}
-      />,
-    );
-
-    const user = userEvent.setup();
-
-    //Select column
-    const selectColumn = screen.getByTestId("select-column");
-    const selectColumnButton = within(selectColumn).getByRole("button");
-    await act(async () => {
-      await user.click(selectColumnButton);
-    });
-
-    const createdAtOption = screen.getByRole("option", { name: "CreatedAt" });
-    expect(createdAtOption).toBeVisible();
-    await act(async () => {
-      await user.click(createdAtOption);
-    });
-    expect(createdAtOption).not.toBeVisible();
-    expect(selectColumn).toHaveTextContent("CreatedAt");
-
-    //Select condition
-    const selectCondition = screen.getByTestId("select-condition");
-    const selectConditionOptions = screen.getByTestId(
-      "select-condition-options",
-    );
-    const selectConditionButton = within(selectCondition).getByRole("button");
-    await act(async () => {
-      await user.click(selectConditionButton);
-    });
-
-    const lteConditionOption = within(selectConditionOptions).getByText("以下");
-    expect(lteConditionOption).toBeVisible();
-    expect(within(selectConditionOptions).getByText("に等しい")).toBeVisible();
-    expect(
-      within(selectConditionOptions).getByText("より大きい"),
-    ).toBeVisible();
-    expect(
-      within(selectConditionOptions).getByText("より小さい"),
-    ).toBeVisible();
-    expect(within(selectConditionOptions).getByText("以上")).toBeVisible();
-
-    expect(within(selectConditionOptions).queryByText("を含む")).toBeNull();
-
-    await act(async () => {
-      await user.click(lteConditionOption);
-    });
-
-    expect(lteConditionOption).not.toBeVisible();
-    expect(selectCondition).toHaveTextContent("以下");
-
-    //Input value
-    const inputValue = screen.getByTestId("select-input-value");
-    await act(async () => {
-      await user.click(inputValue);
-      await user.type(inputValue, "2023-11-14");
-    });
-    expect(inputValue).toHaveValue("2023-11-14");
-
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual(
-        { createdAt: { lte: "2023-11-14" } }, //Returned date is in 2023-11-14 format
+describe(
+  "<CustomFilter />",
+  () => {
+    it("Renders the component correctly when locale is set as English", () => {
+      let currentFilters: GraphQLQueryFilter = {};
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_EN}
+          isVisible={true}
+        />,
       );
-    });
-  });
+      expect(screen.getByText("Reset Filter")).toBeVisible();
+      expect(screen.getByText("Column")).toBeVisible();
+      expect(screen.getByText("Select Column")).toBeVisible();
+      expect(screen.getByText("Condition")).toBeVisible();
+      expect(screen.getByText("Select Condition")).toBeVisible();
+      expect(screen.getByText("Value")).toBeVisible();
+      expect(screen.getByPlaceholderText("Input Value")).toBeVisible();
+      expect(
+        screen.getByRole("button", {
+          name: "Add Filter",
+        }),
+      ).toBeVisible();
 
-  it("Renders Boolean type correctly", async () => {
-    let currentFilters: GraphQLQueryFilter = {};
-
-    render(
-      <CustomFilter
-        columns={columns}
-        onChange={(currentState: GraphQLQueryFilter) => {
-          currentFilters = currentState;
-        }}
-        localization={LOCALIZATION_JA}
-        isVisible={true}
-      />,
-    );
-
-    const user = userEvent.setup();
-
-    //Select column
-    const selectColumn = screen.getByTestId("select-column");
-    const selectColumnButton = within(selectColumn).getByRole("button");
-    await act(async () => {
-      await user.click(selectColumnButton);
+      //Check filters
+      expect(currentFilters).toEqual({});
     });
 
-    const creditCardUsedOption = screen.getByRole("option", {
-      name: "CreditCardUsed",
-    });
-    expect(creditCardUsedOption).toBeVisible();
-    await act(async () => {
-      await user.click(creditCardUsedOption);
-    });
-    expect(creditCardUsedOption).not.toBeVisible();
-    expect(selectColumn).toHaveTextContent("CreditCardUsed");
+    it("Renders the component correctly when locale is set as Japanese", () => {
+      let currentFilters: GraphQLQueryFilter = {};
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          isVisible={true}
+        />,
+      );
+      expect(screen.getByText("フィルタをリセット")).toBeVisible();
+      expect(screen.getByText("列")).toBeVisible();
+      expect(screen.getByText("列を選択")).toBeVisible();
+      expect(screen.getByText("条件")).toBeVisible();
+      expect(screen.getByText("条件を選択")).toBeVisible();
+      expect(screen.getByText("値")).toBeVisible();
+      expect(screen.getByPlaceholderText("値を入力")).toBeVisible();
+      expect(
+        screen.getByRole("button", {
+          name: "条件追加",
+        }),
+      ).toBeVisible();
 
-    //Select condition
-    const selectCondition = screen.getByTestId("select-condition");
-    const selectConditionOptions = screen.getByTestId(
-      "select-condition-options",
-    );
-    const selectConditionButton = within(selectCondition).getByRole("button");
-    await act(async () => {
-      await user.click(selectConditionButton);
-    });
-
-    const eqConditionOption = within(selectConditionOptions).getByText(
-      "に等しい",
-    );
-    expect(eqConditionOption).toBeVisible();
-
-    expect(
-      within(selectConditionOptions).getByText("に等しくない"),
-    ).toBeVisible();
-    expect(screen.queryByText("を含む")).toBeNull();
-    expect(screen.queryByText("より大きい")).toBeNull();
-    expect(screen.queryByText("より小さい")).toBeNull();
-    expect(screen.queryByText("以上")).toBeNull();
-    expect(screen.queryByText("以下")).toBeNull();
-
-    expect(screen.queryByText("を含む")).toBeNull();
-
-    await act(async () => {
-      await user.click(eqConditionOption);
+      //Check filters
+      expect(currentFilters).toEqual({});
     });
 
-    expect(eqConditionOption).not.toBeVisible();
-    expect(selectCondition).toHaveTextContent("に等しい");
+    it("Renders ENUM type correctly", async () => {
+      let currentFilters: GraphQLQueryFilter = {};
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          isVisible={true}
+        />,
+      );
 
-    //Select value
-    const selectValue = screen.getByTestId("select-input-value");
-    const selectValueButton = within(selectValue).getByRole("button");
-    await act(async () => {
-      await user.click(selectValueButton);
+      const user = userEvent.setup();
+
+      //Select column
+      const selectColumn = screen.getByTestId("select-column");
+      const selectColumnOptions = screen.getByTestId("select-column-options");
+      const selectColumnButton = within(selectColumn).getByRole("button");
+      await act(async () => {
+        await user.click(selectColumnButton);
+      });
+
+      const statusOption = within(selectColumnOptions).getByText("Status");
+      expect(statusOption).toBeVisible();
+
+      await act(async () => {
+        await user.click(statusOption);
+      });
+
+      expect(statusOption).not.toBeVisible();
+      expect(selectColumn).toHaveTextContent("Status");
+
+      //Select condition
+      const selectCondition = screen.getByTestId("select-condition");
+      const selectConditionOptions = screen.getByTestId(
+        "select-condition-options",
+      );
+      const selectConditionButton = within(selectCondition).getByRole("button");
+      await act(async () => {
+        await user.click(selectConditionButton);
+      });
+
+      const equalConditionOption = within(selectConditionOptions).getByText(
+        "に等しい",
+      );
+      expect(equalConditionOption).toBeVisible();
+      expect(
+        within(selectConditionOptions).getByText("に等しくない"),
+      ).toBeVisible();
+      expect(within(selectConditionOptions).queryByText("を含む")).toBeNull();
+
+      await act(async () => {
+        await user.click(equalConditionOption);
+      });
+
+      expect(equalConditionOption).not.toBeVisible();
+      expect(selectCondition).toHaveTextContent("に等しい");
+
+      //Select value
+      const selectValue = screen.getByTestId("select-input-value");
+      const selectValueOptions = screen.getByTestId(
+        "select-input-value-options",
+      );
+      const selectValueButton = within(selectValue).getByRole("button");
+      await act(async () => {
+        await user.click(selectValueButton);
+      });
+
+      const pendingValueOption =
+        within(selectValueOptions).getByText("pending");
+      expect(pendingValueOption).toBeVisible();
+      expect(within(selectValueOptions).getByText("processing")).toBeVisible();
+      expect(within(selectValueOptions).getByText("success")).toBeVisible();
+      expect(within(selectValueOptions).getByText("failed")).toBeVisible();
+
+      await act(async () => {
+        await user.click(pendingValueOption);
+      });
+
+      expect(pendingValueOption).not.toBeVisible();
+      expect(selectValue).toHaveTextContent("pending");
+
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({ status: { eq: "pending" } });
+      });
     });
 
-    const trueOption = screen.getByRole("option", { name: "true" });
-    expect(trueOption).toBeVisible();
-    expect(screen.getByRole("option", { name: "false" })).toBeVisible();
+    it("Renders string type correctly", async () => {
+      let currentFilters: GraphQLQueryFilter = {};
 
-    await act(async () => {
-      await user.click(trueOption);
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          isVisible={true}
+        />,
+      );
+
+      const user = userEvent.setup();
+
+      // Select column
+      const selectColumn = screen.getByTestId("select-column");
+      const selectColumnOptions = screen.getByTestId("select-column-options");
+      const selectColumnButton = within(selectColumn).getByRole("button");
+      await act(async () => {
+        await user.click(selectColumnButton);
+      });
+
+      const emailOption = within(selectColumnOptions).getByText("Email");
+      expect(emailOption).toBeVisible();
+
+      await act(async () => {
+        await user.click(emailOption);
+      });
+
+      expect(emailOption).not.toBeVisible();
+      expect(selectColumn).toHaveTextContent("Email");
+
+      // Select condition
+      const selectCondition = screen.getByTestId("select-condition");
+      const selectConditionOptions = screen.getByTestId(
+        "select-condition-options",
+      );
+      const selectConditionButton = within(selectCondition).getByRole("button");
+      await act(async () => {
+        await user.click(selectConditionButton);
+      });
+
+      const equalConditionOption = within(selectConditionOptions).getByText(
+        "に等しい",
+      );
+      expect(equalConditionOption).toBeVisible();
+      expect(within(selectConditionOptions).getByText("を含む")).toBeVisible();
+      expect(
+        within(selectConditionOptions).queryByText("に等しくない"),
+      ).toBeNull();
+
+      await act(async () => {
+        await user.click(equalConditionOption);
+      });
+
+      expect(equalConditionOption).not.toBeVisible();
+      expect(selectCondition).toHaveTextContent("に等しい");
+
+      // Input value
+      const inputValue = screen.getByTestId("select-input-value");
+      await act(async () => {
+        await user.click(inputValue);
+        await user.type(inputValue, "test@test.com");
+      });
+
+      expect(inputValue).toHaveValue("test@test.com");
+
+      // Check filters
+      expect(currentFilters).toEqual({ email: { eq: "test@test.com" } });
     });
 
-    expect(trueOption).not.toBeVisible();
-    expect(selectValue).toHaveTextContent("true");
+    it("Renders number type correctly", async () => {
+      let currentFilters: GraphQLQueryFilter = {};
 
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          isVisible={true}
+        />,
+      );
+
+      const user = userEvent.setup();
+
+      // Select column
+      const selectColumn = screen.getByTestId("select-column");
+      const selectColumnOptions = screen.getByTestId("select-column-options");
+      const selectColumnButton = within(selectColumn).getByRole("button");
+      await act(async () => {
+        await user.click(selectColumnButton);
+      });
+
+      const amountOption = within(selectColumnOptions).getByText("Amount");
+      expect(amountOption).toBeVisible();
+
+      await act(async () => {
+        await user.click(amountOption);
+      });
+
+      expect(amountOption).not.toBeVisible();
+      expect(selectColumn).toHaveTextContent("Amount");
+
+      // Select condition
+      const selectCondition = screen.getByTestId("select-condition");
+      const selectConditionOptions = screen.getByTestId(
+        "select-condition-options",
+      );
+      const selectConditionButton = within(selectCondition).getByRole("button");
+      await act(async () => {
+        await user.click(selectConditionButton);
+      });
+
+      const equalConditionOption = within(selectConditionOptions).getByText(
+        "に等しい",
+      );
+      expect(equalConditionOption).toBeVisible();
+      expect(
+        within(selectConditionOptions).getByText("より大きい"),
+      ).toBeVisible();
+      expect(
+        within(selectConditionOptions).getByText("より小さい"),
+      ).toBeVisible();
+      expect(within(selectConditionOptions).getByText("以上")).toBeVisible();
+      expect(within(selectConditionOptions).getByText("以下")).toBeVisible();
+
+      expect(within(selectConditionOptions).queryByText("を含む")).toBeNull();
+
+      await act(async () => {
+        await user.click(equalConditionOption);
+      });
+
+      expect(equalConditionOption).not.toBeVisible();
+      expect(selectCondition).toHaveTextContent("に等しい");
+
+      // Input value
+      const inputValue = await screen.findByTestId("select-input-value");
+      await act(async () => {
+        fireEvent.change(inputValue, { target: { value: "800" } });
+      });
+
+      expect(inputValue).toHaveValue(800);
+
+      // Check filters
+      expect(currentFilters).toEqual({ amount: { eq: "800" } });
     });
-  });
 
-  it("Multiple filter types woks correctly (type AND)", async () => {
-    let currentFilters: GraphQLQueryFilter = {};
+    it("Renders Date type correctly", async () => {
+      let currentFilters: GraphQLQueryFilter = {};
 
-    render(
-      <CustomFilter
-        columns={columns}
-        onChange={(currentState: GraphQLQueryFilter) => {
-          currentFilters = currentState;
-        }}
-        localization={LOCALIZATION_JA}
-        isVisible={true}
-      />,
-    );
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          isVisible={true}
+        />,
+      );
 
-    const user = userEvent.setup();
+      const user = userEvent.setup();
 
-    //Select column
-    await selectColumn(screen, user, 0, "CreditCardUsed");
-    //Select condition
-    await selectCondition(screen, user, 0, "に等しい");
-    //Select value
-    await selectValue(screen, user, 0, "true");
+      //Select column
+      const selectColumn = screen.getByTestId("select-column");
+      const selectColumnButton = within(selectColumn).getByRole("button");
+      await act(async () => {
+        await user.click(selectColumnButton);
+      });
 
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+      const createdAtOption = screen.getByRole("option", { name: "CreatedAt" });
+      expect(createdAtOption).toBeVisible();
+      await act(async () => {
+        await user.click(createdAtOption);
+      });
+      expect(createdAtOption).not.toBeVisible();
+      expect(selectColumn).toHaveTextContent("CreatedAt");
+
+      //Select condition
+      const selectCondition = screen.getByTestId("select-condition");
+      const selectConditionOptions = screen.getByTestId(
+        "select-condition-options",
+      );
+      const selectConditionButton = within(selectCondition).getByRole("button");
+      await act(async () => {
+        await user.click(selectConditionButton);
+      });
+
+      const lteConditionOption = within(selectConditionOptions).getByText(
+        "以下",
+      );
+      expect(lteConditionOption).toBeVisible();
+      expect(
+        within(selectConditionOptions).getByText("に等しい"),
+      ).toBeVisible();
+      expect(
+        within(selectConditionOptions).getByText("より大きい"),
+      ).toBeVisible();
+      expect(
+        within(selectConditionOptions).getByText("より小さい"),
+      ).toBeVisible();
+      expect(within(selectConditionOptions).getByText("以上")).toBeVisible();
+
+      expect(within(selectConditionOptions).queryByText("を含む")).toBeNull();
+
+      await act(async () => {
+        await user.click(lteConditionOption);
+      });
+
+      expect(lteConditionOption).not.toBeVisible();
+      expect(selectCondition).toHaveTextContent("以下");
+
+      //Input value
+      const inputValue = screen.getByTestId("select-input-value");
+      await act(async () => {
+        await user.click(inputValue);
+        await user.type(inputValue, "2023-11-14");
+      });
+      expect(inputValue).toHaveValue("2023-11-14");
+
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual(
+          { createdAt: { lte: "2023-11-14" } }, //Returned date is in 2023-11-14 format
+        );
+      });
     });
 
-    //Add new filter row
-    await addFilter(screen, user);
+    it("Renders Boolean type correctly", async () => {
+      let currentFilters: GraphQLQueryFilter = {};
 
-    //Select joint condition
-    await selectJointCondition(screen, user, 1, "AND");
-    //Select column
-    await selectColumn(screen, user, 1, "Status");
-    //Select condition
-    await selectCondition(screen, user, 1, "に等しい");
-    //Select value
-    await selectValue(screen, user, 1, "success");
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          isVisible={true}
+        />,
+      );
 
-    //Add new filter row
-    await addFilter(screen, user);
+      const user = userEvent.setup();
 
-    //Select joint condition
-    await selectJointCondition(screen, user, 2, "AND");
-    //Select column
-    await selectColumn(screen, user, 2, "CreatedAt");
-    //Select condition
-    await selectCondition(screen, user, 2, "以下");
-    //Input value
-    await inputValue(screen, user, 2, "2023-11-14");
+      //Select column
+      const selectColumn = screen.getByTestId("select-column");
+      const selectColumnButton = within(selectColumn).getByRole("button");
+      await act(async () => {
+        await user.click(selectColumnButton);
+      });
 
-    //Add new filter row
-    await addFilter(screen, user);
+      const creditCardUsedOption = screen.getByRole("option", {
+        name: "CreditCardUsed",
+      });
+      expect(creditCardUsedOption).toBeVisible();
+      await act(async () => {
+        await user.click(creditCardUsedOption);
+      });
+      expect(creditCardUsedOption).not.toBeVisible();
+      expect(selectColumn).toHaveTextContent("CreditCardUsed");
 
-    //Select joint condition
-    await selectJointCondition(screen, user, 3, "AND");
-    //Select column
-    await selectColumn(screen, user, 3, "Email");
-    //Select condition
-    await selectCondition(screen, user, 3, "に等しい");
-    //Select value
-    await inputValue(screen, user, 3, "test@test.com");
+      //Select condition
+      const selectCondition = screen.getByTestId("select-condition");
+      const selectConditionOptions = screen.getByTestId(
+        "select-condition-options",
+      );
+      const selectConditionButton = within(selectCondition).getByRole("button");
+      await act(async () => {
+        await user.click(selectConditionButton);
+      });
 
-    //Add new filter row
-    await addFilter(screen, user);
+      const eqConditionOption = within(selectConditionOptions).getByText(
+        "に等しい",
+      );
+      expect(eqConditionOption).toBeVisible();
 
-    //Select joint condition
-    await selectJointCondition(screen, user, 4, "AND");
-    //Select column
-    await selectColumn(screen, user, 4, "Amount");
-    //Select condition
-    await selectCondition(screen, user, 4, "以上");
-    //Input value
-    await inputValue(screen, user, 4, "800");
+      expect(
+        within(selectConditionOptions).getByText("に等しくない"),
+      ).toBeVisible();
+      expect(screen.queryByText("を含む")).toBeNull();
+      expect(screen.queryByText("より大きい")).toBeNull();
+      expect(screen.queryByText("より小さい")).toBeNull();
+      expect(screen.queryByText("以上")).toBeNull();
+      expect(screen.queryByText("以下")).toBeNull();
 
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual({
-        isCreditCard: { eq: "true" },
-        and: {
-          status: { eq: "success" },
+      expect(screen.queryByText("を含む")).toBeNull();
+
+      await act(async () => {
+        await user.click(eqConditionOption);
+      });
+
+      expect(eqConditionOption).not.toBeVisible();
+      expect(selectCondition).toHaveTextContent("に等しい");
+
+      //Select value
+      const selectValue = screen.getByTestId("select-input-value");
+      const selectValueButton = within(selectValue).getByRole("button");
+      await act(async () => {
+        await user.click(selectValueButton);
+      });
+
+      const trueOption = screen.getByRole("option", { name: "true" });
+      expect(trueOption).toBeVisible();
+      expect(screen.getByRole("option", { name: "false" })).toBeVisible();
+
+      await act(async () => {
+        await user.click(trueOption);
+      });
+
+      expect(trueOption).not.toBeVisible();
+      expect(selectValue).toHaveTextContent("true");
+
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+      });
+    });
+
+    it("Multiple filter types woks correctly (type AND)", async () => {
+      let currentFilters: GraphQLQueryFilter = {};
+
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          isVisible={true}
+        />,
+      );
+
+      const user = userEvent.setup();
+
+      //Select column
+      await selectColumn(screen, user, 0, "CreditCardUsed");
+      //Select condition
+      await selectCondition(screen, user, 0, "に等しい");
+      //Select value
+      await selectValue(screen, user, 0, "true");
+
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+      });
+
+      //Add new filter row
+      await addFilter(screen, user);
+
+      //Select joint condition
+      await selectJointCondition(screen, user, 1, "AND");
+      //Select column
+      await selectColumn(screen, user, 1, "Status");
+      //Select condition
+      await selectCondition(screen, user, 1, "に等しい");
+      //Select value
+      await selectValue(screen, user, 1, "success");
+
+      //Add new filter row
+      await addFilter(screen, user);
+
+      //Select joint condition
+      await selectJointCondition(screen, user, 2, "AND");
+      //Select column
+      await selectColumn(screen, user, 2, "CreatedAt");
+      //Select condition
+      await selectCondition(screen, user, 2, "以下");
+      //Input value
+      await inputValue(screen, user, 2, "2023-11-14");
+
+      //Add new filter row
+      await addFilter(screen, user);
+
+      //Select joint condition
+      await selectJointCondition(screen, user, 3, "AND");
+      //Select column
+      await selectColumn(screen, user, 3, "Email");
+      //Select condition
+      await selectCondition(screen, user, 3, "に等しい");
+      //Select value
+      await inputValue(screen, user, 3, "test@test.com");
+
+      //Add new filter row
+      await addFilter(screen, user);
+
+      //Select joint condition
+      await selectJointCondition(screen, user, 4, "AND");
+      //Select column
+      await selectColumn(screen, user, 4, "Amount");
+      //Select condition
+      await selectCondition(screen, user, 4, "以上");
+      //Input value
+      await inputValue(screen, user, 4, "800");
+
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({
+          isCreditCard: { eq: "true" },
           and: {
-            createdAt: { lte: "2023-11-14" },
+            status: { eq: "success" },
             and: {
-              email: { eq: "test@test.com" },
+              createdAt: { lte: "2023-11-14" },
               and: {
-                amount: { gte: "800" },
+                email: { eq: "test@test.com" },
+                and: {
+                  amount: { gte: "800" },
+                },
               },
             },
           },
-        },
+        });
       });
     });
-  });
 
-  it("Multiple filter types woks correctly (type OR)", async () => {
-    let currentFilters: GraphQLQueryFilter = {};
+    it("Multiple filter types woks correctly (type OR)", async () => {
+      let currentFilters: GraphQLQueryFilter = {};
 
-    render(
-      <CustomFilter
-        columns={columns}
-        onChange={(currentState: GraphQLQueryFilter) => {
-          currentFilters = currentState;
-        }}
-        localization={LOCALIZATION_JA}
-        isVisible={true}
-      />,
-    );
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          isVisible={true}
+        />,
+      );
 
-    const user = userEvent.setup();
+      const user = userEvent.setup();
 
-    //Select column
-    await selectColumn(screen, user, 0, "CreditCardUsed");
-    //Select condition
-    await selectCondition(screen, user, 0, "に等しい");
-    //Select value
-    await selectValue(screen, user, 0, "true");
+      //Select column
+      await selectColumn(screen, user, 0, "CreditCardUsed");
+      //Select condition
+      await selectCondition(screen, user, 0, "に等しい");
+      //Select value
+      await selectValue(screen, user, 0, "true");
 
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
-    });
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+      });
 
-    //Add new filter row
-    await addFilter(screen, user);
+      //Add new filter row
+      await addFilter(screen, user);
 
-    //Select joint condition
-    await selectJointCondition(screen, user, 1, "OR");
-    //Select column
-    await selectColumn(screen, user, 1, "Status");
-    //Select condition
-    await selectCondition(screen, user, 1, "に等しい");
-    //Select value
-    await selectValue(screen, user, 1, "success");
+      //Select joint condition
+      await selectJointCondition(screen, user, 1, "OR");
+      //Select column
+      await selectColumn(screen, user, 1, "Status");
+      //Select condition
+      await selectCondition(screen, user, 1, "に等しい");
+      //Select value
+      await selectValue(screen, user, 1, "success");
 
-    //Add new filter row
-    await addFilter(screen, user);
+      //Add new filter row
+      await addFilter(screen, user);
 
-    //Select joint condition
-    await selectJointCondition(screen, user, 2, "OR");
-    //Select column
-    await selectColumn(screen, user, 2, "CreatedAt");
-    //Select condition
-    await selectCondition(screen, user, 2, "以下");
-    //Input value
-    await inputValue(screen, user, 2, "2023-11-14");
+      //Select joint condition
+      await selectJointCondition(screen, user, 2, "OR");
+      //Select column
+      await selectColumn(screen, user, 2, "CreatedAt");
+      //Select condition
+      await selectCondition(screen, user, 2, "以下");
+      //Input value
+      await inputValue(screen, user, 2, "2023-11-14");
 
-    //Add new filter row
-    await addFilter(screen, user);
+      //Add new filter row
+      await addFilter(screen, user);
 
-    //Select joint condition
-    await selectJointCondition(screen, user, 3, "OR");
-    //Select column
-    await selectColumn(screen, user, 3, "Email");
-    //Select condition
-    await selectCondition(screen, user, 3, "に等しい");
-    //Select value
-    await inputValue(screen, user, 3, "test@test.com");
+      //Select joint condition
+      await selectJointCondition(screen, user, 3, "OR");
+      //Select column
+      await selectColumn(screen, user, 3, "Email");
+      //Select condition
+      await selectCondition(screen, user, 3, "に等しい");
+      //Select value
+      await inputValue(screen, user, 3, "test@test.com");
 
-    //Add new filter row
-    await addFilter(screen, user);
+      //Add new filter row
+      await addFilter(screen, user);
 
-    //Select joint condition
-    await selectJointCondition(screen, user, 4, "OR");
-    //Select column
-    await selectColumn(screen, user, 4, "Amount");
-    //Select condition
-    await selectCondition(screen, user, 4, "以上");
-    //Input value
-    await inputValue(screen, user, 4, "800");
+      //Select joint condition
+      await selectJointCondition(screen, user, 4, "OR");
+      //Select column
+      await selectColumn(screen, user, 4, "Amount");
+      //Select condition
+      await selectCondition(screen, user, 4, "以上");
+      //Input value
+      await inputValue(screen, user, 4, "800");
 
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual({
-        isCreditCard: { eq: "true" },
-        or: {
-          status: { eq: "success" },
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({
+          isCreditCard: { eq: "true" },
           or: {
-            createdAt: { lte: "2023-11-14" },
+            status: { eq: "success" },
             or: {
-              email: { eq: "test@test.com" },
+              createdAt: { lte: "2023-11-14" },
               or: {
-                amount: { gte: "800" },
+                email: { eq: "test@test.com" },
+                or: {
+                  amount: { gte: "800" },
+                },
               },
             },
           },
-        },
-      });
-    });
-  });
-
-  it("Can delete a filter row", async () => {
-    let currentFilters: GraphQLQueryFilter = {};
-
-    render(
-      <CustomFilter
-        columns={columns}
-        onChange={(currentState: GraphQLQueryFilter) => {
-          currentFilters = currentState;
-        }}
-        localization={LOCALIZATION_JA}
-        isVisible={true}
-      />,
-    );
-
-    const user = userEvent.setup();
-
-    //Select column
-    await selectColumn(screen, user, 0, "CreditCardUsed");
-    //Select condition
-    await selectCondition(screen, user, 0, "に等しい");
-    //Select value
-    await selectValue(screen, user, 0, "true");
-
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
-    });
-
-    //Add new filter row
-    await addFilter(screen, user);
-
-    //Select joint condition
-    await selectJointCondition(screen, user, 1, "AND");
-    //Select column
-    await selectColumn(screen, user, 1, "Status");
-    //Select condition
-    await selectCondition(screen, user, 1, "に等しい");
-    //Select value
-    await selectValue(screen, user, 1, "success");
-
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual({
-        isCreditCard: { eq: "true" },
-        and: { status: { eq: "success" } },
+        });
       });
     });
 
-    //Delete filter row
-    await deleteFilter(screen, user, 1);
+    it("Can delete a filter row", async () => {
+      let currentFilters: GraphQLQueryFilter = {};
 
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
-    });
-  });
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          isVisible={true}
+        />,
+      );
 
-  it("Can reset all filter rows", async () => {
-    let currentFilters: GraphQLQueryFilter = {};
+      const user = userEvent.setup();
 
-    render(
-      <CustomFilter
-        columns={columns}
-        onChange={(currentState: GraphQLQueryFilter) => {
-          currentFilters = currentState;
-        }}
-        localization={LOCALIZATION_JA}
-        isVisible={true}
-      />,
-    );
+      //Select column
+      await selectColumn(screen, user, 0, "CreditCardUsed");
+      //Select condition
+      await selectCondition(screen, user, 0, "に等しい");
+      //Select value
+      await selectValue(screen, user, 0, "true");
 
-    const user = userEvent.setup();
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+      });
 
-    //Select column
-    await selectColumn(screen, user, 0, "CreditCardUsed");
-    //Select condition
-    await selectCondition(screen, user, 0, "に等しい");
-    //Select value
-    await selectValue(screen, user, 0, "true");
+      //Add new filter row
+      await addFilter(screen, user);
 
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
-    });
+      //Select joint condition
+      await selectJointCondition(screen, user, 1, "AND");
+      //Select column
+      await selectColumn(screen, user, 1, "Status");
+      //Select condition
+      await selectCondition(screen, user, 1, "に等しい");
+      //Select value
+      await selectValue(screen, user, 1, "success");
 
-    //Add new filter row
-    await addFilter(screen, user);
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({
+          isCreditCard: { eq: "true" },
+          and: { status: { eq: "success" } },
+        });
+      });
 
-    //Select joint condition
-    await selectJointCondition(screen, user, 1, "AND");
-    //Select column
-    await selectColumn(screen, user, 1, "Status");
-    //Select condition
-    await selectCondition(screen, user, 1, "に等しい");
-    //Select value
-    await selectValue(screen, user, 1, "success");
+      //Delete filter row
+      await deleteFilter(screen, user, 1);
 
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual({
-        isCreditCard: { eq: "true" },
-        and: { status: { eq: "success" } },
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
       });
     });
 
-    //Reset all filter rows
-    await resetAllFilters(screen, user);
+    it("Can reset all filter rows", async () => {
+      let currentFilters: GraphQLQueryFilter = {};
 
-    //Check filters
-    await waitFor(() => {
-      //Wait for the useEffect to update the filters
-      expect(currentFilters).toEqual({}); //GraphQLQueryFilter is reset
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          isVisible={true}
+        />,
+      );
+
+      const user = userEvent.setup();
+
+      //Select column
+      await selectColumn(screen, user, 0, "CreditCardUsed");
+      //Select condition
+      await selectCondition(screen, user, 0, "に等しい");
+      //Select value
+      await selectValue(screen, user, 0, "true");
+
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+      });
+
+      //Add new filter row
+      await addFilter(screen, user);
+
+      //Select joint condition
+      await selectJointCondition(screen, user, 1, "AND");
+      //Select column
+      await selectColumn(screen, user, 1, "Status");
+      //Select condition
+      await selectCondition(screen, user, 1, "に等しい");
+      //Select value
+      await selectValue(screen, user, 1, "success");
+
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({
+          isCreditCard: { eq: "true" },
+          and: { status: { eq: "success" } },
+        });
+      });
+
+      //Reset all filter rows
+      await resetAllFilters(screen, user);
+
+      //Check filters
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({}); //GraphQLQueryFilter is reset
+      });
     });
-  });
-});
+  },
+  { timeout: 10000 },
+);


### PR DESCRIPTION
# Background

Pagination display is broken when the number of items is 0
<!-- Why is this change necessary, how it came to be? -->

# Changes
![スクリーンショット 2024-04-04 9 25 11](https://github.com/tailor-platform/frontend-packages/assets/40710120/90a0faf9-110c-41c5-8314-5c570bc877c7)


<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request includes a change to the `usePagination` function in the `Pagination/utils.ts` file of the `design-systems` package. The change modifies the computation of `from` and `to` variables to account for the case when `table.totalCount` is zero. 

In the `usePagination` function, the `from` and `to` variables are now calculated conditionally based on the `table.totalCount` value. If `table.totalCount` is zero, `from` and `to` are set to zero. Otherwise, their values are calculated as before. This change ensures that the pagination behaves correctly when there are no items in the table.