### PR TITLE
fix(ds): fix query type

### DIFF
--- a/apps/storybook/src/stories/datagrid/utils.ts
+++ b/apps/storybook/src/stories/datagrid/utils.ts
@@ -12,267 +12,227 @@ export const setFilterChange = (
         typeof filter?.status?.eq !== "undefined" ||
         typeof filter?.status?.neq !== "undefined"
       ) {
-        if (typeof filter?.and?.amount !== "string") {
+        if (
+          typeof filter?.and?.amount === "object" &&
+          filter?.and?.amount !== null
+        ) {
           switch (true) {
-            case typeof filter?.and?.amount?.eq !== "undefined":
+            case "eq" in filter.and.amount: {
+              const eqValue = filter.and.amount.eq;
               if (filter?.status?.eq !== "undefined") {
                 setData(
-                  data.filter((row) => {
-                    if (typeof filter?.and?.amount !== "string") {
-                      return (
-                        row.amount === Number(filter.and.amount.eq) &&
-                        row.status === filter.status.eq
-                      );
-                    }
-                  }),
+                  data.filter(
+                    (row) =>
+                      row.amount === Number(eqValue) &&
+                      row.status === filter.status.eq,
+                  ),
                 );
               } else {
                 setData(
-                  data.filter((row) => {
-                    if (typeof filter?.and?.amount !== "string") {
-                      return (
-                        row.amount === Number(filter.and.amount.eq) &&
-                        row.status !== filter.status.neq
-                      );
-                    }
-                  }),
+                  data.filter(
+                    (row) =>
+                      row.amount === Number(eqValue) &&
+                      row.status !== filter.status.neq,
+                  ),
                 );
               }
               break;
-            case typeof filter?.and?.amount?.gt !== "undefined":
+            }
+            case "gt" in filter.and.amount: {
+              const gtValue = filter.and.amount.gt;
               if (filter?.status?.eq !== "undefined") {
                 setData(
-                  data.filter((row) => {
-                    if (typeof filter?.and?.amount !== "string") {
-                      return (
-                        row.amount > Number(filter.and.amount.gt) &&
-                        row.status === filter.status.eq
-                      );
-                    }
-                  }),
+                  data.filter(
+                    (row) =>
+                      row.amount > Number(gtValue) &&
+                      row.status === filter.status.eq,
+                  ),
                 );
               } else {
                 setData(
-                  data.filter((row) => {
-                    if (typeof filter?.and?.amount !== "string") {
-                      return (
-                        row.amount > Number(filter.and.amount.gt) &&
-                        row.status !== filter.status.neq
-                      );
-                    }
-                  }),
+                  data.filter(
+                    (row) =>
+                      row.amount > Number(gtValue) &&
+                      row.status !== filter.status.neq,
+                  ),
                 );
               }
               break;
-            case typeof filter?.and?.amount?.lt !== "undefined":
+            }
+            case "lt" in filter.and.amount: {
+              const ltValue = filter.and.amount.lt;
               if (filter?.status?.eq !== "undefined") {
                 setData(
-                  data.filter((row) => {
-                    if (typeof filter?.and?.amount !== "string") {
-                      return (
-                        row.amount < Number(filter.and.amount.lt) &&
-                        row.status === filter.status.eq
-                      );
-                    }
-                  }),
+                  data.filter(
+                    (row) =>
+                      row.amount < Number(ltValue) &&
+                      row.status === filter.status.eq,
+                  ),
                 );
               } else {
                 setData(
-                  data.filter((row) => {
-                    if (typeof filter?.and?.amount !== "string") {
-                      return (
-                        row.amount < Number(filter.and.amount.lt) &&
-                        row.status !== filter.status.neq
-                      );
-                    }
-                  }),
+                  data.filter(
+                    (row) =>
+                      row.amount < Number(ltValue) &&
+                      row.status !== filter.status.neq,
+                  ),
                 );
               }
               break;
-            case typeof filter?.and?.amount?.gte !== "undefined":
+            }
+            case "gte" in filter.and.amount: {
+              const gteValue = filter.and.amount.gte;
               if (filter?.status?.eq !== "undefined") {
                 setData(
-                  data.filter((row) => {
-                    if (typeof filter?.and?.amount !== "string") {
-                      return (
-                        row.amount >= Number(filter.and.amount.gte) &&
-                        row.status === filter.status.eq
-                      );
-                    }
-                  }),
+                  data.filter(
+                    (row) =>
+                      row.amount >= Number(gteValue) &&
+                      row.status === filter.status.eq,
+                  ),
                 );
               } else {
                 setData(
-                  data.filter((row) => {
-                    if (typeof filter?.and?.amount !== "string") {
-                      return (
-                        row.amount >= Number(filter.and.amount.gte) &&
-                        row.status !== filter.status.neq
-                      );
-                    }
-                  }),
+                  data.filter(
+                    (row) =>
+                      row.amount >= Number(gteValue) &&
+                      row.status !== filter.status.neq,
+                  ),
                 );
               }
               break;
-            case typeof filter?.and?.amount?.lte !== "undefined":
+            }
+            case "lte" in filter.and.amount: {
+              const lteValue = filter.and.amount.lte;
               if (filter?.status?.eq !== "undefined") {
                 setData(
-                  data.filter((row) => {
-                    if (typeof filter?.and?.amount !== "string") {
-                      return (
-                        row.amount <= Number(filter.and.amount.lte) &&
-                        row.status === filter.status.eq
-                      );
-                    }
-                  }),
+                  data.filter(
+                    (row) =>
+                      row.amount <= Number(lteValue) &&
+                      row.status === filter.status.eq,
+                  ),
                 );
               } else {
                 setData(
-                  data.filter((row) => {
-                    if (typeof filter?.and?.amount !== "string") {
-                      return (
-                        row.amount <= Number(filter.and.amount.lte) &&
-                        row.status !== filter.status.neq
-                      );
-                    }
-                  }),
+                  data.filter(
+                    (row) =>
+                      row.amount <= Number(lteValue) &&
+                      row.status !== filter.status.neq,
+                  ),
                 );
               }
               break;
+            }
           }
           break;
         }
       } else {
-        if (typeof filter?.and?.status !== "string") {
+        if (
+          typeof filter?.and?.status === "object" &&
+          filter?.and?.status !== null
+        ) {
           switch (true) {
-            case typeof filter?.and?.status?.eq !== "undefined":
+            case "eq" in filter.and.status: {
+              const eqValue = filter.and.status.eq;
               switch (true) {
                 case typeof filter?.amount?.eq !== "undefined":
                   setData(
-                    data.filter((row) => {
-                      if (typeof filter?.and?.status !== "string") {
-                        return (
-                          row.amount === Number(filter.amount.eq) &&
-                          row.status === filter.and.status.eq
-                        );
-                      }
-                    }),
+                    data.filter(
+                      (row) =>
+                        row.amount === Number(filter.amount.eq) &&
+                        row.status === eqValue,
+                    ),
                   );
                   break;
                 case typeof filter?.amount?.gt !== "undefined":
                   setData(
-                    data.filter((row) => {
-                      if (typeof filter?.and?.status !== "string") {
-                        return (
-                          row.amount > Number(filter.amount.gt) &&
-                          row.status === filter.and.status.eq
-                        );
-                      }
-                    }),
+                    data.filter(
+                      (row) =>
+                        row.amount > Number(filter.amount.gt) &&
+                        row.status === eqValue,
+                    ),
                   );
                   break;
                 case typeof filter?.amount?.lt !== "undefined":
                   setData(
-                    data.filter((row) => {
-                      if (typeof filter?.and?.status !== "string") {
-                        return (
-                          row.amount < Number(filter.amount.lt) &&
-                          row.status === filter.and.status.eq
-                        );
-                      }
-                    }),
+                    data.filter(
+                      (row) =>
+                        row.amount < Number(filter.amount.lt) &&
+                        row.status === eqValue,
+                    ),
                   );
                   break;
                 case typeof filter?.amount?.gte !== "undefined":
                   setData(
-                    data.filter((row) => {
-                      if (typeof filter?.and?.status !== "string") {
-                        return (
-                          row.amount >= Number(filter.amount.gte) &&
-                          row.status === filter.and.status.eq
-                        );
-                      }
-                    }),
+                    data.filter(
+                      (row) =>
+                        row.amount >= Number(filter.amount.gte) &&
+                        row.status === eqValue,
+                    ),
                   );
                   break;
                 case typeof filter?.amount?.lte !== "undefined":
                   setData(
-                    data.filter((row) => {
-                      if (typeof filter?.and?.status !== "string") {
-                        return (
-                          row.amount <= Number(filter.amount.lte) &&
-                          row.status === filter.and.status.eq
-                        );
-                      }
-                    }),
+                    data.filter(
+                      (row) =>
+                        row.amount <= Number(filter.amount.lte) &&
+                        row.status === eqValue,
+                    ),
                   );
                   break;
               }
               break;
-            case typeof filter?.and?.status?.neq !== "undefined":
+            }
+            case "neq" in filter.and.status: {
+              const neqValue = filter.and.status.neq;
               switch (true) {
                 case typeof filter?.amount?.eq !== "undefined":
                   setData(
-                    data.filter((row) => {
-                      if (typeof filter?.and?.status !== "string") {
-                        return (
-                          row.amount === Number(filter.amount.eq) &&
-                          row.status === filter.and.status.neq
-                        );
-                      }
-                    }),
+                    data.filter(
+                      (row) =>
+                        row.amount === Number(filter.amount.eq) &&
+                        row.status !== neqValue,
+                    ),
                   );
                   break;
                 case typeof filter?.amount?.gt !== "undefined":
                   setData(
-                    data.filter((row) => {
-                      if (typeof filter?.and?.status !== "string") {
-                        return (
-                          row.amount > Number(filter.amount.gt) &&
-                          row.status === filter.and.status.neq
-                        );
-                      }
-                    }),
+                    data.filter(
+                      (row) =>
+                        row.amount > Number(filter.amount.gt) &&
+                        row.status !== neqValue,
+                    ),
                   );
                   break;
                 case typeof filter?.amount?.lt !== "undefined":
                   setData(
-                    data.filter((row) => {
-                      if (typeof filter?.and?.status !== "string") {
-                        return (
-                          row.amount < Number(filter.amount.lt) &&
-                          row.status === filter.and.status.neq
-                        );
-                      }
-                    }),
+                    data.filter(
+                      (row) =>
+                        row.amount < Number(filter.amount.lt) &&
+                        row.status !== neqValue,
+                    ),
                   );
                   break;
                 case typeof filter?.amount?.gte !== "undefined":
                   setData(
-                    data.filter((row) => {
-                      if (typeof filter?.and?.status !== "string") {
-                        return (
-                          row.amount >= Number(filter.amount.gte) &&
-                          row.status === filter.and.status.neq
-                        );
-                      }
-                    }),
+                    data.filter(
+                      (row) =>
+                        row.amount >= Number(filter.amount.gte) &&
+                        row.status !== neqValue,
+                    ),
                   );
                   break;
                 case typeof filter?.amount?.lte !== "undefined":
                   setData(
-                    data.filter((row) => {
-                      if (typeof filter?.and?.status !== "string") {
-                        return (
-                          row.amount <= Number(filter.amount.lte) &&
-                          row.status === filter.and.status.neq
-                        );
-                      }
-                    }),
+                    data.filter(
+                      (row) =>
+                        row.amount <= Number(filter.amount.lte) &&
+                        row.status !== neqValue,
+                    ),
                   );
                   break;
               }
               break;
+            }
           }
         }
       }

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.20.8",
+  "version": "0.20.9",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/types.ts
@@ -112,7 +112,7 @@ export type JointCondition = {
   disabled: boolean;
 };
 export type GraphQLQueryFilter = {
-  [fieldName: string]: { [operator: string]: string } | GraphQLQueryFilter;
+  [fieldName: string]: { [operator: string]: unknown } | GraphQLQueryFilter;
 };
 
 export const GraphQLFilterOperator = {


### PR DESCRIPTION
# Background

Cannot set type other than string to defaultFilter
<!-- Why is this change necessary, how it came to be? -->

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request primarily involves changes to the `apps/storybook/src/stories/datagrid/utils.ts` file to enhance data filtering functionality, and updates to the `packages/design-systems/package.json` and `packages/design-systems/src/components/composite/Datagrid/types.ts` files. The changes in the `utils.ts` file involve improvements to the `setFilterChange` function, specifically to the data filtering conditions. The `package.json` file has been updated to reflect a new version of the design systems package, and the `types.ts` file has been modified to allow for more flexible GraphQL query filters.

Key changes include:

### Enhancements to data filtering:

* [`apps/storybook/src/stories/datagrid/utils.ts`](diffhunk://#diff-24ac253e2db33b789d62ac00120b726c85986a2f410660df1ec3ed8874d9d98cL15-R238): The `setFilterChange` function has been significantly refactored to improve the data filtering conditions. This was achieved by changing the type checking for `filter?.and?.amount` and `filter?.and?.status` from `string` to `object`, and ensuring they are not `null`. The filtering conditions were also simplified by directly using the `eq`, `gt`, `lt`, `gte`, and `lte` properties of `filter.and.amount` and `filter.and.status` to filter the data. This makes the code more readable and efficient.

### Updates to design systems package:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the design systems package was updated from `0.20.8` to `0.20.9`.

### Changes to GraphQL query filter types:

* [`packages/design-systems/src/components/composite/Datagrid/types.ts`](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917L115-R115): The `GraphQLQueryFilter` type was modified to allow for more flexible filters. The operator's value type was changed from `string` to `unknown`, allowing it to accept any type. This change provides more flexibility when constructing GraphQL query filters.