### PR TITLE
fix(auth): invalid session guard

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.2",
+  "version": "0.6.3-preview.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.3-preview.1",
+  "version": "0.6.3",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.3-preview.0",
+  "version": "0.6.3-preview.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/src/client/hooks.test.tsx
+++ b/packages/auth/src/client/hooks.test.tsx
@@ -7,7 +7,7 @@ import { TailorAuthProvider } from "./provider";
 import { buildMockServer, mockAuthConfig, mockSession } from "@tests/mocks";
 import { withMockReplace } from "@tests/helper";
 import { internalClientSessionPath } from "@server/middleware/internal";
-import { internalClientSessionLoader } from "@core/loader";
+import { internalSessionLoader } from "@core/loader";
 
 const mockProvider = (props: React.PropsWithChildren) => (
   <TailorAuthProvider config={mockAuthConfig}>
@@ -18,7 +18,7 @@ const mockProvider = (props: React.PropsWithChildren) => (
 const mockServer = buildMockServer();
 beforeAll(() => mockServer.listen());
 afterEach(() => {
-  internalClientSessionLoader.clear();
+  internalSessionLoader.clear();
   mockServer.resetHandlers();
 });
 afterAll(() => mockServer.close());

--- a/packages/auth/src/client/hooks.test.tsx
+++ b/packages/auth/src/client/hooks.test.tsx
@@ -109,9 +109,9 @@ describe("useSession", () => {
 
   it("redirects users to the unauthorized route if session is empty", async () => {
     mockServer.use(
-      http.post(mockAuthConfig.appUrl(internalClientSessionPath), () => {
+      http.get(mockAuthConfig.appUrl(internalClientSessionPath), () => {
         return HttpResponse.json({
-          token: undefined,
+          token: null,
         });
       }),
     );
@@ -124,12 +124,14 @@ describe("useSession", () => {
     };
 
     const replaceMock = vi.fn();
-    await withMockReplace(replaceMock, () => {
+    await withMockReplace(replaceMock, async () => {
       render(<TestComponent />, {
         wrapper: SuspendingWrapper,
       });
-    });
 
-    expect(replaceMock).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(replaceMock).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -190,7 +190,7 @@ export const useSession = (options?: SessionOption) => {
   assertWindowIsAvailable();
 
   const session = internalClientSessionLoader.getSuspense(config);
-  if (options?.required && session?.token === null) {
+  if (options?.required && !session?.token) {
     window.location.replace(config.appUrl(internalUnauthorizedPath));
   }
 

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -5,10 +5,7 @@ import {
   internalLogoutPath,
   internalUnauthorizedPath,
 } from "@server/middleware/internal";
-import {
-  internalClientSessionLoader,
-  internalUserinfoLoader,
-} from "@core/loader";
+import { internalSessionLoader, internalUserinfoLoader } from "@core/loader";
 
 const NoWindowError = new Error(
   "window object should be available to use this function",
@@ -189,7 +186,7 @@ export const useSession = (options?: SessionOption) => {
 
   assertWindowIsAvailable();
 
-  const session = internalClientSessionLoader.getSuspense(config);
+  const session = internalSessionLoader.getSuspense(config);
   if (options?.required && !session?.token) {
     window.location.replace(config.appUrl(internalUnauthorizedPath));
   }

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -184,15 +184,15 @@ export const usePlatform = () => {
  * };
  * ```
  */
-export const useSession = (options?: SessionOption): SessionResult => {
+export const useSession = (options?: SessionOption) => {
   const config = useTailorAuth();
 
   assertWindowIsAvailable();
 
-  const internalClientSession = internalClientSessionLoader.get();
-  if (options?.required && internalClientSession?.token === undefined) {
+  const session = internalClientSessionLoader.getSuspense(config);
+  if (options?.required && session?.token === null) {
     window.location.replace(config.appUrl(internalUnauthorizedPath));
   }
 
-  return internalClientSessionLoader.getSuspense(config);
+  return { token: session.token };
 };

--- a/packages/auth/src/client/index.ts
+++ b/packages/auth/src/client/index.ts
@@ -5,10 +5,5 @@
  * @packageDocumentation
  */
 export { TailorAuthProvider } from "@client/provider";
-export type {
-  LoginParams,
-  LogoutParams,
-  useAuth,
-  usePlatform,
-  useSession,
-} from "@client/hooks";
+export type { LoginParams, LogoutParams } from "@client/hooks";
+export { useAuth, usePlatform, useSession } from "@client/hooks";

--- a/packages/auth/src/core/loader.ts
+++ b/packages/auth/src/core/loader.ts
@@ -2,9 +2,9 @@ import { internalClientSessionPath } from "@server/middleware/internal";
 import { Config } from "@core/config";
 import { SessionResult, UserInfo } from "@core/types";
 
-// SingletonLoader is a class that abstracts out the logic of loading a resource from a remote server,
+// SuspenseLoader is a class that abstracts out the logic of loading a resource from a remote server,
 // and caches the result for React Suspense support in client components.
-class SingletonLoader<R> {
+class SuspenseLoader<R> {
   private value: R | null;
   private error: Error | null;
 
@@ -46,11 +46,11 @@ class SingletonLoader<R> {
 const fetchSession = async (config: Config) =>
   fetch(config.appUrl(internalClientSessionPath));
 
-export const internalClientSessionLoader = new SingletonLoader<SessionResult>(
+export const internalSessionLoader = new SuspenseLoader<SessionResult>(
   fetchSession,
 );
 
-export const internalUserinfoLoader = new SingletonLoader<UserInfo>(
+export const internalUserinfoLoader = new SuspenseLoader<UserInfo>(
   async (config) => {
     const resp = await fetchSession(config);
     const session = (await resp.json()) as unknown as SessionResult;

--- a/packages/auth/src/core/loader.ts
+++ b/packages/auth/src/core/loader.ts
@@ -26,10 +26,6 @@ class SingletonLoader<R> {
       });
   }
 
-  get() {
-    return this.value;
-  }
-
   getSuspense(config: Config) {
     if (this.error) {
       throw this.error;

--- a/packages/auth/src/core/types.ts
+++ b/packages/auth/src/core/types.ts
@@ -10,7 +10,7 @@ export type Session = {
 };
 
 export type SessionResult = {
-  token: string;
+  token: string | null;
 };
 
 export type SessionOption = {

--- a/packages/auth/src/server/middleware/internal.ts
+++ b/packages/auth/src/server/middleware/internal.ts
@@ -11,7 +11,7 @@ export const callbackByStrategy = (strategy: string = "default") =>
 export const internalClientSessionPath = "/__auth/session" as const;
 export const internalClientSessionHandler: RouteHandler = ({ request }) => {
   const tailorToken = request.cookies.get("tailor.token");
-  return NextResponse.json({ token: tailorToken?.value });
+  return NextResponse.json({ token: tailorToken?.value || null });
 };
 
 // Internal path redirecting (through middleware) to `unauthorizedPath` set in ContextConfig


### PR DESCRIPTION
# Background

`required` option in `useSession` does not work as expected that it does not redirect to the fallback path.

# Changes

This pull request includes changes to the `@tailor-platform/auth` package. The most important changes involve renaming and modifying the `SingletonLoader` class to `SuspenseLoader`, refactoring the `useSession` hook, and updating the `internalClientSessionLoader` to `internalSessionLoader`. 

Package version update:

* [`packages/auth/package.json`](diffhunk://#diff-79fbe1d958aec3ec2b3d46cdc5b9b34cd834f48550895ce9484f10c0f77a4a8fL3-R3): The version of `@tailor-platform/auth` was updated from `0.6.2` to `0.6.3`.

Refactoring of `useSession` hook:

* [`packages/auth/src/client/hooks.ts`](diffhunk://#diff-1dfa41d6294f9c71b94051574daaf578d5b857d293c03c4f18553b3a8059f32aL187-R194): The `useSession` hook was refactored to use `internalSessionLoader` instead of `internalClientSessionLoader`, and the condition to replace the window location was updated. Also, the return value was modified to only return the token from the session.

Loader class renaming and modification:

* [`packages/auth/src/core/loader.ts`](diffhunk://#diff-8e986a4db2b146cea53c824b12f69e31b0f0e89605dc28a4c5bf8a7b70a09fd9L5-R7): The `SingletonLoader` class was renamed to `SuspenseLoader`, and the `get` method was removed. The `internalClientSessionLoader` and `internalUserinfoLoader` were updated to use the new `SuspenseLoader` class. [[1]](diffhunk://#diff-8e986a4db2b146cea53c824b12f69e31b0f0e89605dc28a4c5bf8a7b70a09fd9L5-R7) [[2]](diffhunk://#diff-8e986a4db2b146cea53c824b12f69e31b0f0e89605dc28a4c5bf8a7b70a09fd9L29-L32) [[3]](diffhunk://#diff-8e986a4db2b146cea53c824b12f69e31b0f0e89605dc28a4c5bf8a7b70a09fd9L53-R53)

Changes in `internalClientSessionLoader` to `internalSessionLoader`:

* `packages/auth/src/client/hooks.test.tsx`, `packages/auth/src/client/hooks.ts`: All instances of `internalClientSessionLoader` were replaced with `internalSessionLoader`. [[1]](diffhunk://#diff-14dda08b1f46c69de796284f6b62e52ef480ff0ff760d479d87830bf812b3c47L10-R10) [[2]](diffhunk://#diff-14dda08b1f46c69de796284f6b62e52ef480ff0ff760d479d87830bf812b3c47L21-R21) [[3]](diffhunk://#diff-1dfa41d6294f9c71b94051574daaf578d5b857d293c03c4f18553b3a8059f32aL8-R8)

Changes in `useSession` tests:

* [`packages/auth/src/client/hooks.test.tsx`](diffhunk://#diff-14dda08b1f46c69de796284f6b62e52ef480ff0ff760d479d87830bf812b3c47L112-R114): The test for `useSession` was updated to reflect the changes in the hook. This includes changing the HTTP method from `post` to `get`, changing the token value from `undefined` to `null`, and updating the `withMockReplace` function to be asynchronous. [[1]](diffhunk://#diff-14dda08b1f46c69de796284f6b62e52ef480ff0ff760d479d87830bf812b3c47L112-R114) [[2]](diffhunk://#diff-14dda08b1f46c69de796284f6b62e52ef480ff0ff760d479d87830bf812b3c47L127-R137)

Other changes:

* [`packages/auth/src/client/index.ts`](diffhunk://#diff-60520c4d0d412231406df667daff23e9fbda5c26c15d881d7e4d3db4be758650L8-R9): The export statement was modified to separately export types and functions.
* `packages/auth/src/core/types.ts`, `packages/auth/src/server/middleware/internal.ts`: The `SessionResult` type was updated to allow `null` for the `token` property, and the `internalClientSessionHandler` was updated to return `null` instead of `undefined` for the token. [[1]](diffhunk://#diff-72a1192e9fd78f0ad20cfd2f9793679357724c7aec0e4c361fd15ccd70117288L13-R13) [[2]](diffhunk://#diff-24559462a2cbfde34fcc77c85adac105ee3ca149f2e3a83d91c0397ba12db5b6L14-R14)
