### PR TITLE
 fix(ds): update tanstack table and refactoring meta and accessorkey

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -19,7 +19,7 @@
     "@ark-ui/anatomy": "^2.3.1",
     "@ark-ui/react": "~2.2.3",
     "@hookform/resolvers": "^3.3.2",
-    "@tanstack/react-table": "^8.12.0",
+    "@tanstack/react-table": "^8.15.3",
     "@theme-toggles/react": "^4.1.0",
     "lucide-react": "^0.292.0",
     "react": "^18.2.0",

--- a/apps/storybook/src/stories/datagrid/DataGridMultilingualStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridMultilingualStory.tsx
@@ -33,7 +33,7 @@ export const DataGridMultilingualStory = ({
     onFilterChange: (filter) => {
       setFilterChange(filter, originData, setData);
     },
-    totalCount: 14,
+    totalCount: data.length,
     pagination: {
       pageIndex: 0,
       pageSize: 5,

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -54,7 +54,7 @@
     "@hookform/resolvers": "^3.3.2",
     "@swc/core": "^1.3.100",
     "@tailor-platform/dev-config": "workspace:*",
-    "@tanstack/table-core": "^8.12.0",
+    "@tanstack/table-core": "^8.15.3",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.1",
@@ -73,7 +73,7 @@
   "dependencies": {
     "@pandacss/types": "^0.36.0",
     "@radix-ui/react-slot": "^1.0.2",
-    "@tanstack/react-table": "^8.12.0",
+    "@tanstack/react-table": "^8.15.3",
     "deepmerge-ts": "^5.1.0",
     "react-hook-form": "^7.48.2"
   },

--- a/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/HideShow.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/HideShow.test.tsx
@@ -30,8 +30,6 @@ const columns: ColumnDef<Payment>[] = [
     meta: {
       type: "enum",
       enumType: PaymentStatus,
-      //accessorKey is not provided at compile time inside ColumnDef https://github.com/TanStack/table/issues/4423
-      accessorKey: "status",
     },
   },
   {
@@ -39,7 +37,6 @@ const columns: ColumnDef<Payment>[] = [
     header: "Email",
     meta: {
       type: "string",
-      accessorKey: "email",
     },
   },
   {
@@ -47,7 +44,6 @@ const columns: ColumnDef<Payment>[] = [
     header: "Amount",
     meta: {
       type: "number",
-      accessorKey: "amount",
     },
   },
 ];

--- a/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/PinnedColumn.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/PinnedColumn.test.tsx
@@ -29,8 +29,6 @@ const columns: ColumnDef<Payment>[] = [
     meta: {
       type: "enum",
       enumType: PaymentStatus,
-      //accessorKey is not provided at compile time inside ColumnDef https://github.com/TanStack/table/issues/4423
-      accessorKey: "status",
     },
   },
   {
@@ -38,7 +36,6 @@ const columns: ColumnDef<Payment>[] = [
     header: "Email",
     meta: {
       type: "string",
-      accessorKey: "email",
     },
   },
   {
@@ -46,7 +43,6 @@ const columns: ColumnDef<Payment>[] = [
     header: "Amount",
     meta: {
       type: "number",
-      accessorKey: "amount",
     },
   },
 ];

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.test.tsx
@@ -30,8 +30,6 @@ const columns: ColumnDef<Payment>[] = [
     meta: {
       type: "enum",
       enumType: PaymentStatus,
-      //accessorKey is not provided at compile time inside ColumnDef https://github.com/TanStack/table/issues/4423
-      accessorKey: "status",
     },
   },
   {
@@ -39,7 +37,6 @@ const columns: ColumnDef<Payment>[] = [
     header: "Email",
     meta: {
       type: "string",
-      accessorKey: "email",
     },
   },
   {
@@ -47,7 +44,6 @@ const columns: ColumnDef<Payment>[] = [
     header: "Amount",
     meta: {
       type: "number",
-      accessorKey: "amount",
     },
   },
 ];

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -113,19 +113,22 @@ export const DataGrid = <TData extends Record<string, unknown>>(
   useEffect(() => {
     //Get header titles from table columns
     const cusotmFilterFields: Column<TData>[] = table.columns
-      .map((column) => {
+      .flatMap((column) => {
         if ("accessorKey" in column) {
-          return {
-            //This is temporary structure, we will change this logic in coming days as required
-            label: column.header as string,
-            value: column.header as string,
-            accessorKey: column.accessorKey as string,
-            disabled: false,
-            meta: column.meta,
-          };
+          return [
+            {
+              //This is temporary structure, we will change this logic in coming days as required
+              label: column.header as string,
+              value: column.header as string,
+              accessorKey: column.accessorKey as string,
+              disabled: false,
+              meta: column.meta,
+            }
+          ];
+        } else {
+          return []
         }
       })
-      .filter(Boolean) as Column<TData>[];
 
     setCustomFilterFields(cusotmFilterFields);
   }, [table]);

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -112,11 +112,11 @@ export const DataGrid = <TData extends Record<string, unknown>>(
 
   useEffect(() => {
     //Get header titles from table columns
-    //This is temporary structure, we will change this logic in coming days as required
     const cusotmFilterFields: Column<TData>[] = table.columns
       .map((column) => {
         if ("accessorKey" in column) {
           return {
+            //This is temporary structure, we will change this logic in coming days as required
             label: column.header as string,
             value: column.header as string,
             accessorKey: column.accessorKey as string,

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -112,8 +112,8 @@ export const DataGrid = <TData extends Record<string, unknown>>(
 
   useEffect(() => {
     //Get header titles from table columns
-    const cusotmFilterFields: Column<TData>[] = table.columns
-      .flatMap((column) => {
+    const cusotmFilterFields: Column<TData>[] = table.columns.flatMap(
+      (column) => {
         if ("accessorKey" in column) {
           return [
             {
@@ -123,12 +123,13 @@ export const DataGrid = <TData extends Record<string, unknown>>(
               accessorKey: column.accessorKey as string,
               disabled: false,
               meta: column.meta,
-            }
+            },
           ];
         } else {
-          return []
+          return [];
         }
-      })
+      },
+    );
 
     setCustomFilterFields(cusotmFilterFields);
   }, [table]);

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -113,6 +113,7 @@ export const DataGrid = <TData extends Record<string, unknown>>(
     const columnHeaders: Column<TData>[] = [];
     table.getHeaderGroups().map((headerGroup) => {
       headerGroup.headers.map((header) => {
+        console.log("header.column.columnDef", header.column.columnDef);
         columnHeaders.push({
           //This is temporary structure, we will change this logic in coming days as required
           label: header.column.columnDef.header as string,

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
@@ -60,48 +60,48 @@ type Payment = {
 
 const columns: Column<Payment>[] = [
   {
+    accessorKey: "status",
     label: "Status",
     value: "Status",
     meta: {
       type: "enum",
       enumType: PaymentStatus,
-      accessorKey: "status",
     },
     disabled: false,
   },
   {
+    accessorKey: "email",
     label: "Email",
     value: "Email",
     meta: {
       type: "string",
-      accessorKey: "email",
     },
     disabled: false,
   },
   {
+    accessorKey: "amount",
     label: "Amount",
     value: "Amount",
     meta: {
       type: "number",
-      accessorKey: "amount",
     },
     disabled: false,
   },
   {
+    accessorKey: "createdAt",
     label: "CreatedAt",
     value: "CreatedAt",
     meta: {
       type: "date",
-      accessorKey: "createdAt",
     },
     disabled: false,
   },
   {
+    accessorKey: "isCreditCard",
     label: "CreditCardUsed",
     value: "CreditCardUsed",
     meta: {
       type: "boolean",
-      accessorKey: "isCreditCard",
     },
     disabled: false,
   },

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
@@ -51,7 +51,7 @@ export const FilterRow = <TData extends Record<string, unknown>>(
   const DATE_INPUT_PLACEHOLDER = "YYYY-MM-DD";
   const filterConditions = getLocalizedFilterConditions(localization);
   const selectedColumnObject = columns.find((column) => {
-    return column.meta?.accessorKey === currentFilter.column;
+    return column.accessorKey === currentFilter.column;
   });
 
   const onChangeColumn = useCallback(
@@ -59,7 +59,7 @@ export const FilterRow = <TData extends Record<string, unknown>>(
       const column = columns.find((column) => column.label === value[0]);
       const nextFilter = {
         ...currentFilter,
-        column: column?.meta?.accessorKey || "",
+        column: column?.accessorKey || "",
         condition: "",
         value: "",
       };

--- a/packages/design-systems/src/components/composite/Datagrid/type.d.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/type.d.ts
@@ -1,0 +1,8 @@
+import "@tanstack/react-table"; //or vue, svelte, solid, qwik, etc.
+
+declare module "@tanstack/react-table" {
+  interface ColumnMeta {
+    type: string;
+    enumType?: Record<string, string>;
+  }
+}

--- a/packages/design-systems/src/components/composite/Datagrid/type.d.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/type.d.ts
@@ -1,4 +1,4 @@
-import "@tanstack/react-table"; //or vue, svelte, solid, qwik, etc.
+import "@tanstack/react-table";
 
 declare module "@tanstack/react-table" {
   interface ColumnMeta {

--- a/packages/design-systems/src/components/composite/Datagrid/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/types.ts
@@ -6,7 +6,6 @@ import type {
   OnChangeFn,
   PaginationState,
   RowSelectionState,
-  TableMeta,
 } from "@tanstack/react-table";
 import type { Table, Updater } from "@tanstack/table-core/build/lib/types";
 import { CollectionItem } from "@ark-ui/react/select";
@@ -30,6 +29,7 @@ export interface DataGridInstance<
   onFilterChange?: (filters: GraphQLQueryFilter) => void;
   defaultFilter?: GraphQLQueryFilter;
   localization?: Localization;
+  columns: ColumnDef<TData>[];
 }
 export type UseDataGridProps<TData> = {
   data: TData[];
@@ -55,13 +55,6 @@ export type UseDataGridProps<TData> = {
   enablePinning?: boolean;
   columnPinning?: ColumnPinningState;
   setColumnPinning?: (updater: Updater<ColumnPinningState>) => void;
-  meta?: TableMeta<TData>;
-};
-export type ColumnMetaWithTypeInfo<TData> = ColumnMeta<TData, unknown> & {
-  type: string;
-  enumType?: Record<string, string>;
-  //https://github.com/TanStack/table/issues/4423
-  accessorKey: string;
 };
 export type HideShowProps<TData extends Record<string, unknown>> = {
   allColumnsHandler: () => (event: unknown) => void;
@@ -72,8 +65,9 @@ export type HideShowProps<TData extends Record<string, unknown>> = {
 export type Column<TData> = {
   label: string;
   value: string;
+  accessorKey: string;
   disabled?: boolean;
-  meta?: ColumnMetaWithTypeInfo<TData>;
+  meta?: ColumnMeta<TData, unknown>;
 };
 export type CustomFilterProps<TData> = {
   columns: Array<Column<TData>>;
@@ -93,7 +87,7 @@ export type FilterRowState = {
 export type FilterRowProps<TData> = {
   columns: Array<Column<TData>>;
   onDelete: () => void;
-  meta?: ColumnMetaWithTypeInfo<TData>;
+  meta?: ColumnMeta<TData, unknown>;
   onChange: (currentState: FilterRowState) => void;
   localization: Localization;
   isFirstRow: boolean;

--- a/packages/design-systems/src/components/composite/Datagrid/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/types.ts
@@ -6,6 +6,7 @@ import type {
   OnChangeFn,
   PaginationState,
   RowSelectionState,
+  TableMeta,
 } from "@tanstack/react-table";
 import type { Table, Updater } from "@tanstack/table-core/build/lib/types";
 import { CollectionItem } from "@ark-ui/react/select";
@@ -54,6 +55,7 @@ export type UseDataGridProps<TData> = {
   enablePinning?: boolean;
   columnPinning?: ColumnPinningState;
   setColumnPinning?: (updater: Updater<ColumnPinningState>) => void;
+  meta?: TableMeta<TData>;
 };
 export type ColumnMetaWithTypeInfo<TData> = ColumnMeta<TData, unknown> & {
   type: string;

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -112,5 +112,6 @@ export const useDataGrid = <TData extends RowLike>({
     onFilterChange,
     defaultFilter,
     localization,
+    columns,
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2(react-hook-form@7.48.2)
       '@tanstack/react-table':
-        specifier: ^8.12.0
-        version: 8.13.2(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^8.15.3
+        version: 8.15.3(react-dom@18.2.0)(react@18.2.0)
       '@theme-toggles/react':
         specifier: ^4.1.0
         version: 4.1.0(react-dom@18.2.0)(react@18.2.0)
@@ -260,8 +260,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(@types/react@18.2.42)(react@18.2.0)
       '@tanstack/react-table':
-        specifier: ^8.12.0
-        version: 8.13.2(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^8.15.3
+        version: 8.15.3(react-dom@18.2.0)(react@18.2.0)
       deepmerge-ts:
         specifier: ^5.1.0
         version: 5.1.0
@@ -282,8 +282,8 @@ importers:
         specifier: workspace:*
         version: link:../dev-config
       '@tanstack/table-core':
-        specifier: ^8.12.0
-        version: 8.13.2
+        specifier: ^8.15.3
+        version: 8.15.3
       '@testing-library/jest-dom':
         specifier: ^6.1.5
         version: 6.1.5(vitest@1.0.2)
@@ -8078,20 +8078,20 @@ packages:
     resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
     dev: true
 
-  /@tanstack/react-table@8.13.2(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-b6mR3mYkjRtJ443QZh9sc7CvGTce81J35F/XMr0OoWbx0KIM7TTTdyNP2XKObvkLpYnLpCrYDwI3CZnLezWvpg==}
+  /@tanstack/react-table@8.15.3(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-aocQ4WpWiAh7R+yxNp+DGQYXeVACh5lv2kk96DjYgFiHDCB0cOFoYMT/pM6eDOzeMXR9AvPoLeumTgq8/0qX+w==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: '>=16'
-      react-dom: '>=16'
+      react: '>=16.8'
+      react-dom: '>=16.8'
     dependencies:
-      '@tanstack/table-core': 8.13.2
+      '@tanstack/table-core': 8.15.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@tanstack/table-core@8.13.2:
-    resolution: {integrity: sha512-/2saD1lWBUV6/uNAwrsg2tw58uvMJ07bO2F1IWMxjFRkJiXKQRuc3Oq2aufeobD3873+4oIM/DRySIw7+QsPPw==}
+  /@tanstack/table-core@8.15.3:
+    resolution: {integrity: sha512-wOgV0HfEvuMOv8RlqdR9MdNNqq0uyvQtP39QOvGlggHvIObOE4exS+D5LGO8LZ3LUXxId2IlUKcHDHaGujWhUg==}
     engines: {node: '>=12'}
 
   /@testing-library/dom@9.3.3:


### PR DESCRIPTION
# Background

Support type-safe meta type definition
https://tailor.atlassian.net/browse/FL-157
Resolve duplicated `accessorKey` field by updating react-table to the latest version
https://tailor.atlassian.net/browse/FL-158

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request primarily focuses on updating the `@tanstack/react-table` package and refactoring the `DataGrid` component in the `design-systems` package. The changes include updating the package version in multiple `package.json` files, removing redundant `accessorKey` properties in `ColumnDef` arrays, and refactoring the `DataGrid` component to simplify the code and improve functionality.

Package updates:
* [`apps/storybook/package.json`](diffhunk://#diff-b6c0dcaee715dbce8821255c58de066b960ad35ecd820d5bd09f912543b4ee4cL22-R22): Updated `@tanstack/react-table` package from version `8.12.0` to `8.15.3`.
* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): Updated `@tanstack/react-table` and `@tanstack/table-core` packages from version `8.12.0` to `8.15.3`, and incremented the package version from `0.21.0` to `0.21.1`. [[1]](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3) [[2]](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L57-R57) [[3]](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L76-R76)
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL66-R67): Updated the `@tanstack/react-table` and `@tanstack/table-core` packages from version `8.12.0` to `8.15.3` in multiple locations. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL66-R67) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL263-R264) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL285-R286) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8081-R8094)

Code simplification:
* [`apps/storybook/src/stories/datagrid/DataGridMultilingualStory.tsx`](diffhunk://#diff-911a2e733fe52b5c2e7ef27b702ea692815c9debbba673fed11c9b2a796186a7L36-R36): Changed `totalCount` from a hardcoded value to the length of the `data` array.
* `packages/design-systems/src/components/composite/Datagrid/ColumnFeature/HideShow.test.tsx`, `packages/design-systems/src/components/composite/Datagrid/ColumnFeature/PinnedColumn.test.tsx`, `packages/design-systems/src/components/composite/Datagrid/Datagrid.test.tsx`, `packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx`: Removed redundant `accessorKey` properties in `ColumnDef` arrays. [[1]](diffhunk://#diff-8f0d9fd0d000c98d21d11211fd07cf35529854a335c34f627cf64a06665291faL33-L50) [[2]](diffhunk://#diff-be70824e9ee62fe52d5ffe06e610c2a68dbd3a3f439572ce3bdd895f6bb469adL32-L49) [[3]](diffhunk://#diff-ade26a9458c214ae8f382954a5dd2232044b78817c0c91b19066e746e22ce474L33-L50) [[4]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcR63-L104)

`DataGrid` refactoring:
* [`packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx`](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL35-R35): Refactored to simplify the code and improve functionality. Changes include removing the unused `ColumnMetaWithTypeInfo` type, renaming `columnHeaders` to `cusotmFilterFields`, and updating the logic to get header titles from table columns. [[1]](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL35-R35) [[2]](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL51-R53) [[3]](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL112-R130) [[4]](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL181-R186) [[5]](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL259-R267)
* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx`](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL54-R62): Updated to use `accessorKey` instead of `meta?.accessorKey` for `currentFilter.column`.
* [`packages/design-systems/src/components/composite/Datagrid/types.ts`](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917R32): Removed the unused `ColumnMetaWithTypeInfo` type and added `accessorKey` to the `Column` type. [[1]](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917R32) [[2]](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917L58-L63) [[3]](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917R68-R70) [[4]](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917L94-R90)
* [`packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx`](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917R32): Added `columns` to the `UseDataGridProps` type. [[1]](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917R32) [[2]](diffhunk://#diff-14aa5328e3b002bc6281f392fbba405593aa8ee29bc6f844d5f2c1191cefc377R115)