### PR TITLE
fix(ds): fix css bug

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -90,6 +90,7 @@ export const DataGrid = <TData extends Record<string, unknown>>(
 
   const getCommonPinningStyles = (
     column: ColumnTanstak<TData>,
+    isHeader?: boolean,
   ): CSSProperties => {
     const isPinned = column.getIsPinned();
     const isLastLeftPinnedColumn =
@@ -105,8 +106,10 @@ export const DataGrid = <TData extends Record<string, unknown>>(
           : undefined,
       left: isPinned === "left" ? `${column.getStart("left")}px` : undefined,
       right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
+      position: isHeader || isPinned ? "sticky" : "relative",
       opacity: isPinned ? 0.95 : 1,
       zIndex: isPinned ? 1 : 0,
+      backgroundColor: isHeader || isPinned ? "white" : "inherit",
     };
   };
 
@@ -213,7 +216,7 @@ export const DataGrid = <TData extends Record<string, unknown>>(
                     style={{
                       minWidth:
                         header.id === "select" ? "54px" : header.getSize(), //First column with checkboxes
-                      ...getCommonPinningStyles(header.column),
+                      ...getCommonPinningStyles(header.column, true),
                     }}
                     draggable={
                       !table.getState().columnSizingInfo.isResizingColumn

--- a/packages/design-systems/src/theme/slot-recipes/datagrid.ts
+++ b/packages/design-systems/src/theme/slot-recipes/datagrid.ts
@@ -24,7 +24,7 @@ export const datagrid = defineSlotRecipe({
     },
     table: {
       backgroundColor: "canvas.base",
-      width: "100%",
+      width: "auto",
       borderWidth: "0.5px",
       borderColor: "border.default",
       tableLayout: "fixed",


### PR DESCRIPTION
# Background

<!-- Why is this change necessary, how it came to be? -->
fix css error because of FL-149

![スクリーンショット 2024-04-10 18 03 17](https://github.com/tailor-platform/frontend-packages/assets/40710120/4022360b-6f6b-422f-a688-54ff1d2dfd08)

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request includes important updates to the `@tailor-platform/design-systems` package and the `Datagrid` component. The changes mainly involve updating the version of the package, enhancing the `DataGrid` component, and modifying the `datagrid` slot recipe.

Package version update:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the `@tailor-platform/design-systems` package was updated from `0.22.0` to `0.22.1`.

Enhancements to `DataGrid` component:

* [`packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx`](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cR93): The `getCommonPinningStyles` function was updated to accept a new parameter `isHeader` to customize styles for header cells.
* [`packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx`](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cR109-R112): The returned style object from `getCommonPinningStyles` was updated to include new properties `position` and `backgroundColor` based on the `isHeader` or `isPinned` status.
* [`packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx`](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL216-R219): The `getCommonPinningStyles` function was called with the `isHeader` parameter set to `true` in the style object for header cells.

Changes to `datagrid` slot recipe:

* [`packages/design-systems/src/theme/slot-recipes/datagrid.ts`](diffhunk://#diff-6e7c19af9e55eb0f78020e03670f34958c831c01320af967b1456e7f2de63f1bL27-R27): The `width` property of the `table` object was changed from `100%` to `auto` to allow the table to adjust its width automatically.