### PR TITLE
fix(ds): fix pageSize list to be variable

### DIFF
--- a/apps/storybook/src/stories/datagrid/DataGridManualPaginationStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridManualPaginationStory.tsx
@@ -17,7 +17,7 @@ export type DataGridManualPaginationStoryProps = {
 };
 
 export const DataGridManualPaginationStory = ({
-  pageSize = 5,
+  pageSize = 8,
 }: DataGridManualPaginationStoryProps) => {
   const [data, setData] = useState<Payment[]>(originData.slice(0, pageSize));
 

--- a/apps/storybook/src/stories/datagrid/DataGridPagination.stories.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridPagination.stories.tsx
@@ -25,7 +25,7 @@ type Story = StoryObj<DataGridPaginationStoryProps>;
 
 export const Default: Story = {
   args: {
-    pageSize: 5,
+    pageSize: 20,
   },
   render: (args) => <DataGridPaginationStory {...args} />,
   parameters: {

--- a/apps/storybook/src/stories/datagrid/DataGridPaginationStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridPaginationStory.tsx
@@ -26,6 +26,7 @@ export const DataGridPaginationStory = ({
       pageIndex: 0,
       pageSize: pageSize,
     },
+    selectList: [5, 10, 15, 20],
   });
 
   return (

--- a/apps/storybook/src/stories/datagrid/DataGridPaginationStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridPaginationStory.tsx
@@ -26,7 +26,7 @@ export const DataGridPaginationStory = ({
       pageIndex: 0,
       pageSize: pageSize,
     },
-    selectList: [5, 10, 15, 20],
+    pageSizeOptions: [5, 10, 15, 20],
   });
 
   return (

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
@@ -36,11 +36,8 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
     pageIndex: 0,
     pageSize: table.initialState.pagination.pageSize,
   });
-  const { from, to, pages, pageCount, isNextPage, selectList } = usePagination(
-    table,
-    pageIndex,
-    pageSize,
-  );
+  const { from, to, pages, pageCount, isNextPage, pageSizeOptions } =
+    usePagination(table, pageIndex, pageSize);
   const handlePageChange = (detail: PageChangeDetails) => {
     table.handlePageChange && table.handlePageChange(detail);
   };
@@ -51,7 +48,7 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
         <Text>{localization.pagination.rowsPerPage}</Text>
         <Select.Root
           className={classes.root}
-          items={selectList}
+          items={pageSizeOptions}
           positioning={{ sameWidth: true }}
           closeOnSelect
           onValueChange={(e: ValueChangeDetails<CollectionItem>) => {
@@ -80,7 +77,7 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
                   id="jointConditions"
                   data-testid="select-page-size-options"
                 >
-                  {selectList.map((item) => (
+                  {pageSizeOptions.map((item) => (
                     <Select.Item
                       className={classes.item}
                       key={"pageSize" + item}

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
@@ -20,7 +20,7 @@ import {
 import { Text } from "../../../Text";
 import { Button } from "../../../Button";
 import { IconButton } from "../../../IconButton";
-import { selectList, Select, usePagination } from "./utils";
+import { Select, usePagination } from "./utils";
 import { Localization } from "@locales/types";
 
 const classes = select();
@@ -36,7 +36,7 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
     pageIndex: 0,
     pageSize: table.initialState.pagination.pageSize,
   });
-  const { from, to, pages, pageCount, isNextPage } = usePagination(
+  const { from, to, pages, pageCount, isNextPage, selectList } = usePagination(
     table,
     pageIndex,
     pageSize,

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
@@ -15,7 +15,7 @@ import { DataGridInstance, ValueChangeDetails } from "../types";
 import { Text } from "../../../Text";
 import { Button } from "../../../Button";
 import { IconButton } from "../../../IconButton";
-import { selectList, Select, usePagination } from "./utils";
+import { Select, usePagination } from "./utils";
 import { Localization } from "@locales/types";
 
 const classes = select();
@@ -32,7 +32,11 @@ export const Pagination = <TData extends Record<string, unknown>>({
     [table],
   );
   const pageSize = useMemo(() => table.getState().pagination.pageSize, [table]);
-  const { from, to, pages } = usePagination(table, pageIndex, pageSize);
+  const { from, to, pages, selectList } = usePagination(
+    table,
+    pageIndex,
+    pageSize,
+  );
 
   return (
     <HStack justifyContent={"flex-end"} gap={8}>

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
@@ -32,7 +32,7 @@ export const Pagination = <TData extends Record<string, unknown>>({
     [table],
   );
   const pageSize = useMemo(() => table.getState().pagination.pageSize, [table]);
-  const { from, to, pages, selectList } = usePagination(
+  const { from, to, pages, pageSizeOptions } = usePagination(
     table,
     pageIndex,
     pageSize,
@@ -44,7 +44,7 @@ export const Pagination = <TData extends Record<string, unknown>>({
         <Text>{localization.pagination.rowsPerPage}</Text>
         <Select.Root
           className={classes.root}
-          items={selectList}
+          items={pageSizeOptions}
           positioning={{ sameWidth: true }}
           closeOnSelect
           onValueChange={(e: ValueChangeDetails<CollectionItem>) => {
@@ -72,7 +72,7 @@ export const Pagination = <TData extends Record<string, unknown>>({
                   id="jointConditions"
                   data-testid="select-page-size-options"
                 >
-                  {selectList.map((item) => (
+                  {pageSizeOptions.map((item) => (
                     <Select.Item
                       className={classes.item}
                       key={"pageSize" + item}

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/utils.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/utils.ts
@@ -5,7 +5,7 @@ import { DataGridInstance, Page } from "../types";
 
 const ELLIPSIS_SIZE = 4;
 
-export const selectList = ["5", "20", "50", "100", "500", "1000"];
+export const defaultSelectList = ["5", "20", "50", "100", "500", "1000"];
 
 export const usePagination = <TData extends Record<string, unknown>>(
   table: DataGridInstance<TData>,
@@ -39,7 +39,22 @@ export const usePagination = <TData extends Record<string, unknown>>(
     return pageIndex === pageCount - 1;
   }, [pageIndex, pageCount]);
 
-  return { from, to, pages, pageCount, isNextPage };
+  const selectList = useMemo(
+    () => {
+      const tmpSelectList =
+        table.selectList && table.selectList.length > 0
+          ? table.selectList.map((s) => s.toString())
+          : defaultSelectList;
+      return [...new Set([...tmpSelectList, pageSize.toString()])].sort(
+        (a, b) => Number(a) - Number(b),
+      );
+    },
+    // We have to run this function only when first time, but this way of writing will cause an error due to lint rules, so we excluded it here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  return { from, to, pages, pageCount, isNextPage, selectList };
 };
 
 export const Select = {

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/utils.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/utils.ts
@@ -39,11 +39,11 @@ export const usePagination = <TData extends Record<string, unknown>>(
     return pageIndex === pageCount - 1;
   }, [pageIndex, pageCount]);
 
-  const selectList = useMemo(
+  const pageSizeOptions = useMemo(
     () => {
       const tmpSelectList =
-        table.selectList && table.selectList.length > 0
-          ? table.selectList.map((s) => s.toString())
+        table.pageSizeOptions && table.pageSizeOptions.length > 0
+          ? table.pageSizeOptions.map((s) => s.toString())
           : defaultSelectList;
       return [...new Set([...tmpSelectList, pageSize.toString()])].sort(
         (a, b) => Number(a) - Number(b),
@@ -54,7 +54,7 @@ export const usePagination = <TData extends Record<string, unknown>>(
     [],
   );
 
-  return { from, to, pages, pageCount, isNextPage, selectList };
+  return { from, to, pages, pageCount, isNextPage, pageSizeOptions };
 };
 
 export const Select = {

--- a/packages/design-systems/src/components/composite/Datagrid/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/types.ts
@@ -30,7 +30,7 @@ export interface DataGridInstance<
   defaultFilter?: GraphQLQueryFilter;
   localization?: Localization;
   columns: ColumnDef<TData>[];
-  selectList?: number[];
+  pageSizeOptions?: number[];
 }
 export type UseDataGridProps<TData> = {
   data: TData[];
@@ -56,7 +56,7 @@ export type UseDataGridProps<TData> = {
   enablePinning?: boolean;
   columnPinning?: ColumnPinningState;
   setColumnPinning?: (updater: Updater<ColumnPinningState>) => void;
-  selectList?: number[];
+  pageSizeOptions?: number[];
 };
 export type HideShowProps<TData extends Record<string, unknown>> = {
   allColumnsHandler: () => (event: unknown) => void;

--- a/packages/design-systems/src/components/composite/Datagrid/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/types.ts
@@ -30,6 +30,7 @@ export interface DataGridInstance<
   defaultFilter?: GraphQLQueryFilter;
   localization?: Localization;
   columns: ColumnDef<TData>[];
+  selectList?: number[];
 }
 export type UseDataGridProps<TData> = {
   data: TData[];
@@ -55,6 +56,7 @@ export type UseDataGridProps<TData> = {
   enablePinning?: boolean;
   columnPinning?: ColumnPinningState;
   setColumnPinning?: (updater: Updater<ColumnPinningState>) => void;
+  selectList?: number[];
 };
 export type HideShowProps<TData extends Record<string, unknown>> = {
   allColumnsHandler: () => (event: unknown) => void;

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -29,6 +29,7 @@ export const useDataGrid = <TData extends RowLike>({
   enableRowSelection = false,
   onRowSelectionChange,
   rowSelection,
+  selectList = [],
 }: UseDataGridProps<TData>): DataGridInstance<TData> => {
   const { pageIndex = 0, pageSize = 50 } = pagination || {};
   const [columnPinningState, setColumnPinningState] =
@@ -113,5 +114,6 @@ export const useDataGrid = <TData extends RowLike>({
     defaultFilter,
     localization,
     columns,
+    selectList,
   };
 };

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -29,7 +29,7 @@ export const useDataGrid = <TData extends RowLike>({
   enableRowSelection = false,
   onRowSelectionChange,
   rowSelection,
-  selectList = [],
+  pageSizeOptions = [],
 }: UseDataGridProps<TData>): DataGridInstance<TData> => {
   const { pageIndex = 0, pageSize = 50 } = pagination || {};
   const [columnPinningState, setColumnPinningState] =
@@ -114,6 +114,6 @@ export const useDataGrid = <TData extends RowLike>({
     defaultFilter,
     localization,
     columns,
-    selectList,
+    pageSizeOptions,
   };
 };


### PR DESCRIPTION
# Background

[Pagination sizes should be configureable](https://tailor.atlassian.net/browse/FL-159)
<!-- Why is this change necessary, how it came to be? -->

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request mainly focuses on the modification of pagination behavior in the data grid components of the design system. The changes include the adjustment of default page sizes, the introduction of a selectable list of page sizes, and an update to the version of the design system. 

Adjustments to default page sizes:

* [`apps/storybook/src/stories/datagrid/DataGridManualPaginationStory.tsx`](diffhunk://#diff-137d0cbed8df6d3dc9bd10366cdca12fda403c6ef703eab1c2ef7126b07fc0ebL20-R20): The default page size for the `DataGridManualPaginationStory` component has been increased from 5 to 8.
* [`apps/storybook/src/stories/datagrid/DataGridPagination.stories.tsx`](diffhunk://#diff-2aab47129b9d28406edf3712b2b9ba3fa98ce2e94a86993edbaff7af9356c5dfL28-R28): The default page size for the `DataGridPaginationStory` component has been increased from 5 to 20.

Introduction of selectable page sizes:

* [`apps/storybook/src/stories/datagrid/DataGridPaginationStory.tsx`](diffhunk://#diff-dab46e6b9d0a77b4b596ff46afd1a2dc0112b9f7171070e45fc3c94bc8d7dd92R29): A selectable list of page sizes has been introduced to the `DataGridPaginationStory` component.
* `packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx` and `packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx`: The `selectList` has been removed from the import statement and is now being returned from the `usePagination` hook. [[1]](diffhunk://#diff-b18e0964543b2ec2d14856c16e5fdcd91ac494a6516b1f6bacd68b4a039cf154L23-R23) [[2]](diffhunk://#diff-cf4ddce20ee1ffa24bf1bad804161e44abdbe499f279fe6bfba9ba369a9b9bcbL18-R18) [[3]](diffhunk://#diff-b18e0964543b2ec2d14856c16e5fdcd91ac494a6516b1f6bacd68b4a039cf154L39-R39) [[4]](diffhunk://#diff-cf4ddce20ee1ffa24bf1bad804161e44abdbe499f279fe6bfba9ba369a9b9bcbL35-R39)
* [`packages/design-systems/src/components/composite/Datagrid/Pagination/utils.ts`](diffhunk://#diff-a241ae1321b8e7147f2898c60b269df394b62d2138c6146f5dde9d9801335786L8-R8): The `selectList` constant has been renamed to `defaultSelectList` and is now returned from the `usePagination` hook. The hook also includes logic to handle the case when a custom `selectList` is provided. [[1]](diffhunk://#diff-a241ae1321b8e7147f2898c60b269df394b62d2138c6146f5dde9d9801335786L8-R8) [[2]](diffhunk://#diff-a241ae1321b8e7147f2898c60b269df394b62d2138c6146f5dde9d9801335786L42-R57)
* `packages/design-systems/src/components/composite/Datagrid/types.ts` and `packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx`: The `selectList` property has been added to the `DataGridInstance` and `UseDataGridProps` types, and is being used in the `useDataGrid` hook. [[1]](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917R33) [[2]](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917R59) [[3]](diffhunk://#diff-14aa5328e3b002bc6281f392fbba405593aa8ee29bc6f844d5f2c1191cefc377R32) [[4]](diffhunk://#diff-14aa5328e3b002bc6281f392fbba405593aa8ee29bc6f844d5f2c1191cefc377R117)

Version update:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the design system has been updated from 0.22.1 to 0.23.0.