### PR TITLE
fix(ds): fix css

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.22.1",
+  "version": "0.23.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/PinnedColumn.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/PinnedColumn.tsx
@@ -56,7 +56,7 @@ export const PinnedColumn = <TData extends Record<string, unknown>>({
           display={"flex"}
           flexDirection={"column"}
           alignItems={"start"}
-          right={0}
+          right={column.getIsPinned() === "left" ? "auto" : 0}
           ref={modalRef}
         >
           <Button

--- a/packages/design-systems/src/theme/slot-recipes/datagrid.ts
+++ b/packages/design-systems/src/theme/slot-recipes/datagrid.ts
@@ -25,6 +25,7 @@ export const datagrid = defineSlotRecipe({
     table: {
       backgroundColor: "canvas.base",
       width: "auto",
+      minWidth: "full",
       borderWidth: "0.5px",
       borderColor: "border.default",
       tableLayout: "fixed",


### PR DESCRIPTION
# Background

https://tailor.atlassian.net/browse/IMA-1040
https://tailor.atlassian.net/browse/IMA-1128
<!-- Why is this change necessary, how it came to be? -->

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request primarily updates the `@tailor-platform/design-systems` package and makes changes to the `PinnedColumn` and `datagrid` components. The most significant changes include a version bump for the design systems package, an update to the `PinnedColumn` component to change the positioning based on the `getIsPinned` method, and the addition of a `minWidth` property to the `datagrid` component.

Version update:
* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the `@tailor-platform/design-systems` package has been updated from `0.22.1` to `0.23.1`.

Component updates:
* [`packages/design-systems/src/components/composite/Datagrid/ColumnFeature/PinnedColumn.tsx`](diffhunk://#diff-9a8f5ea9766647619f5d474019342dfe709724967b103068e3731eb5fc6fe977L59-R59): The `right` property of the `PinnedColumn` component now depends on the `getIsPinned` method. If the column is pinned to the left, the `right` property is set to `auto`; otherwise, it remains `0`.
* [`packages/design-systems/src/theme/slot-recipes/datagrid.ts`](diffhunk://#diff-6e7c19af9e55eb0f78020e03670f34958c831c01320af967b1456e7f2de63f1bR28): A `minWidth` property set to `full` has been added to the `datagrid` component to ensure it takes up the full available width.