### PR TITLE
fix(ds): add localization

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -384,7 +384,7 @@ export const DataGrid = <TData extends Record<string, unknown>>(
               ))
             ) : (
               <TableRow>
-                <TableCell colSpan={colSpan}>No results.</TableCell>
+                <TableCell colSpan={colSpan}>{localization.datagrid.noResults}</TableCell>
               </TableRow>
             )}
           </TableBody>

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -384,7 +384,9 @@ export const DataGrid = <TData extends Record<string, unknown>>(
               ))
             ) : (
               <TableRow>
-                <TableCell colSpan={colSpan}>{localization.datagrid.noResults}</TableCell>
+                <TableCell colSpan={colSpan}>
+                  {localization.datagrid.noResults}
+                </TableCell>
               </TableRow>
             )}
           </TableBody>

--- a/packages/design-systems/src/locales/en.ts
+++ b/packages/design-systems/src/locales/en.ts
@@ -4,6 +4,9 @@ import { Localization } from "./types";
  */
 export const LOCALIZATION_EN: Localization = {
   language: "EN",
+  datagrid: {
+    noResults: "No Results.",
+  },
   columnFeatures: {
     hideShow: {
       showAll: "Show All",

--- a/packages/design-systems/src/locales/ja.ts
+++ b/packages/design-systems/src/locales/ja.ts
@@ -4,6 +4,9 @@ import { Localization } from "./types";
  */
 export const LOCALIZATION_JA: Localization = {
   language: "JA",
+  datagrid: {
+    noResults: "表示可能なデータがありません",
+  },
   columnFeatures: {
     hideShow: {
       showAll: "全て表示",

--- a/packages/design-systems/src/locales/types.ts
+++ b/packages/design-systems/src/locales/types.ts
@@ -1,5 +1,8 @@
 export interface Localization {
   language: string;
+  datagrid: {
+    noResults: string;
+  },
   filter: {
     filterLabel: string;
     filterResetLabel: string;

--- a/packages/design-systems/src/locales/types.ts
+++ b/packages/design-systems/src/locales/types.ts
@@ -2,7 +2,7 @@ export interface Localization {
   language: string;
   datagrid: {
     noResults: string;
-  },
+  };
   filter: {
     filterLabel: string;
     filterResetLabel: string;


### PR DESCRIPTION
# Background

Display "No results" in Japanese
<!-- Why is this change necessary, how it came to be? -->

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request primarily focuses on the internationalization of the `DataGrid` component in the `design-systems` package. The changes introduce a new `datagrid` field in the `Localization` interface to support different languages for the "No Results" message in the `DataGrid` component.

Here are the key changes:

* [`packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx`](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL305-R305): Replaced the hard-coded "No results" message in the `DataGrid` component with a localized version. This version uses the `datagrid.noResults` field from the `localization` object.

Localization changes:

* [`packages/design-systems/src/locales/types.ts`](diffhunk://#diff-23d05766725ea33f62dee80b9e86ba60c162dea3dba29691754d18caad56b073R3-R5): Extended the `Localization` interface with a new `datagrid` field, which includes a `noResults` string field. This allows for localized "No Results" messages.
* [`packages/design-systems/src/locales/en.ts`](diffhunk://#diff-1858a96bd5462cc084b42e493806c658aaba5221402dea60464595a3ad912410R7-R9): Added a `datagrid` field with a `noResults` field to the `LOCALIZATION_EN` object. The `noResults` field is set to "No Results.".
* [`packages/design-systems/src/locales/ja.ts`](diffhunk://#diff-9471627b37051b709de5d94829c2b7a5a7f93beff388d175f45f53cd71df861bR7-R9): Similarly, added a `datagrid` field with a `noResults` field to the `LOCALIZATION_JA` object. The `noResults` field is set to "表示可能なデータがありません", which translates to "No data available for display.".