### PR TITLE
fix(auth): remove server dependencies from apollo-link adapters and client modules

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.4-preview.0",
+  "version": "0.6.4-preview.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.4-preview.1",
+  "version": "0.6.4",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.3",
+  "version": "0.6.4-preview.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/src/adapters/apollo/link.ts
+++ b/packages/auth/src/adapters/apollo/link.ts
@@ -2,8 +2,8 @@ import { from, HttpLink, ServerError } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
 import { onError } from "@apollo/client/link/error";
 import { Config } from "@core/config";
+import { internalClientSessionPath } from "@core/path";
 import { SessionResult } from "@core/types";
-import { internalClientSessionPath } from "@server/middleware/internal";
 
 /**
  * authenticatedHttpLink is a custom ApolloLink that automatically sets tokens in authorization header as a bearer token.

--- a/packages/auth/src/client/hooks.test.tsx
+++ b/packages/auth/src/client/hooks.test.tsx
@@ -6,8 +6,8 @@ import { useAuth, usePlatform, useSession } from "./hooks";
 import { TailorAuthProvider } from "./provider";
 import { buildMockServer, mockAuthConfig, mockSession } from "@tests/mocks";
 import { withMockReplace } from "@tests/helper";
-import { internalClientSessionPath } from "@server/middleware/internal";
 import { internalSessionLoader } from "@core/loader";
+import { internalClientSessionPath } from "@core/path";
 
 const mockProvider = (props: React.PropsWithChildren) => (
   <TailorAuthProvider config={mockAuthConfig}>

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -1,11 +1,11 @@
 import { ErrorResponse, SessionOption, SessionResult } from "@core/types";
 import { useTailorAuth } from "@client/provider";
+import { internalSessionLoader, internalUserinfoLoader } from "@core/loader";
 import {
   callbackByStrategy,
   internalLogoutPath,
   internalUnauthorizedPath,
-} from "@server/middleware/internal";
-import { internalSessionLoader, internalUserinfoLoader } from "@core/loader";
+} from "@core/path";
 
 const NoWindowError = new Error(
   "window object should be available to use this function",

--- a/packages/auth/src/core/loader.ts
+++ b/packages/auth/src/core/loader.ts
@@ -1,4 +1,4 @@
-import { internalClientSessionPath } from "@server/middleware/internal";
+import { internalClientSessionPath } from "@core/path";
 import { Config } from "@core/config";
 import { SessionResult, UserInfo } from "@core/types";
 

--- a/packages/auth/src/core/path.ts
+++ b/packages/auth/src/core/path.ts
@@ -1,0 +1,18 @@
+// Internal path to handle callback from the identity provider
+export const internalCallbackPath = "/__auth/callback" as const;
+export const callbackByStrategy = (strategy: string = "default") =>
+  `/__auth/callback/${strategy}` as const;
+
+// Internal path to fetch token from client components
+// `useSession` hook fetches token from this endpoint by extracting it from cookies.
+export const internalClientSessionPath = "/__auth/session" as const;
+
+// Internal path redirecting (through middleware) to `unauthorizedPath` set in ContextConfig
+// This is the path used in redirection caused by login guard in server components
+// The middleware that reads ContextConfig is in charge of redirecting to the `unauthorizedPath`
+// through this path when unauthorized users guarded in `getServerSession`.
+export const internalUnauthorizedPath = "/__auth/unauthorized" as const;
+
+// Internal path to logout from client components
+// This function deletes the token from cookies and redirects to the login page.
+export const internalLogoutPath = "/__auth/logout" as const;

--- a/packages/auth/src/core/strategies/abstract.ts
+++ b/packages/auth/src/core/strategies/abstract.ts
@@ -112,3 +112,17 @@ export type AbstractStrategy<
    */
   callback(config: Config, params: URLSearchParams): CallbackResult;
 };
+
+export class CallbackError extends Error {
+  constructor(
+    readonly name: string,
+    readonly message: string,
+  ) {
+    super(message);
+  }
+}
+
+export const paramsError = () =>
+  new CallbackError("invalid-params", "code and redirectURI should be filled");
+export const exchangeError = (reason: string) =>
+  new CallbackError("failed-exchange", reason);

--- a/packages/auth/src/core/strategies/minitailor.ts
+++ b/packages/auth/src/core/strategies/minitailor.ts
@@ -1,7 +1,7 @@
 import { AbstractStrategy } from "./abstract";
 import { paramsError } from "@server/middleware/callback";
 import { Config } from "@core/config";
-import { callbackByStrategy } from "@server/middleware/internal";
+import { callbackByStrategy } from "@core/path";
 
 type Options = {
   email: string;

--- a/packages/auth/src/core/strategies/minitailor.ts
+++ b/packages/auth/src/core/strategies/minitailor.ts
@@ -1,5 +1,4 @@
-import { AbstractStrategy } from "./abstract";
-import { paramsError } from "@server/middleware/callback";
+import { AbstractStrategy, paramsError } from "@core/strategies/abstract";
 import { Config } from "@core/config";
 import { callbackByStrategy } from "@core/path";
 

--- a/packages/auth/src/core/strategies/sso.ts
+++ b/packages/auth/src/core/strategies/sso.ts
@@ -1,7 +1,6 @@
-import { AbstractStrategy } from "./abstract";
+import { AbstractStrategy, paramsError } from "@core/strategies/abstract";
 import { Config } from "@core/config";
 import { callbackByStrategy } from "@core/path";
-import { paramsError } from "@server/middleware/callback";
 
 export type Options = { redirectPath: string };
 

--- a/packages/auth/src/core/strategies/sso.ts
+++ b/packages/auth/src/core/strategies/sso.ts
@@ -1,7 +1,7 @@
 import { AbstractStrategy } from "./abstract";
 import { Config } from "@core/config";
+import { callbackByStrategy } from "@core/path";
 import { paramsError } from "@server/middleware/callback";
-import { callbackByStrategy } from "@server/middleware/internal";
 
 export type Options = { redirectPath: string };
 

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -5,8 +5,8 @@
  */
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { internalUnauthorizedPath } from "./middleware/internal";
 import { SessionOption, SessionResult } from "@core/types";
+import { internalUnauthorizedPath } from "@core/path";
 
 /**
  * A function to get token on server components

--- a/packages/auth/src/server/middleware.ts
+++ b/packages/auth/src/server/middleware.ts
@@ -2,15 +2,17 @@ import { NextMiddleware, NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { callbackHandler } from "./middleware/callback";
 import {
-  internalCallbackPath,
   internalClientSessionHandler,
-  internalClientSessionPath,
   internalLogoutHandler,
-  internalLogoutPath,
-  internalUnauthorizedPath,
   internalUnauthroziedHandler,
 } from "./middleware/internal";
 import { Config } from "@core/config";
+import {
+  internalCallbackPath,
+  internalClientSessionPath,
+  internalUnauthorizedPath,
+  internalLogoutPath,
+} from "@core/path";
 
 export type MiddlewareHandlerOptions = {
   /**

--- a/packages/auth/src/server/middleware/callback.test.ts
+++ b/packages/auth/src/server/middleware/callback.test.ts
@@ -2,7 +2,6 @@ import { beforeAll, afterAll, afterEach, describe, expect, it } from "vitest";
 import { NextResponse } from "next/server";
 import { HttpResponse, http } from "msw";
 import { callbackHandler, exchangeError, paramsError } from "./callback";
-import { callbackByStrategy } from "./internal";
 import {
   buildMockServer,
   mockAuthConfig,
@@ -11,6 +10,7 @@ import {
 import { mockSession } from "@tests/mocks";
 import { Config } from "@core/config";
 import { buildRequestWithParams } from "@tests/helper";
+import { callbackByStrategy } from "@core/path";
 
 const mockServer = buildMockServer();
 beforeAll(() => mockServer.listen());

--- a/packages/auth/src/server/middleware/callback.test.ts
+++ b/packages/auth/src/server/middleware/callback.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, afterAll, afterEach, describe, expect, it } from "vitest";
 import { NextResponse } from "next/server";
 import { HttpResponse, http } from "msw";
-import { callbackHandler, exchangeError, paramsError } from "./callback";
+import { callbackHandler } from "./callback";
 import {
   buildMockServer,
   mockAuthConfig,
@@ -11,6 +11,7 @@ import { mockSession } from "@tests/mocks";
 import { Config } from "@core/config";
 import { buildRequestWithParams } from "@tests/helper";
 import { callbackByStrategy } from "@core/path";
+import { paramsError, exchangeError } from "@core/strategies/abstract";
 
 const mockServer = buildMockServer();
 beforeAll(() => mockServer.listen());

--- a/packages/auth/src/server/middleware/callback.ts
+++ b/packages/auth/src/server/middleware/callback.ts
@@ -2,20 +2,7 @@ import { NextResponse } from "next/server";
 import { RouteHandler } from "@server/middleware";
 import { ErrorResponse, Session } from "@core/types";
 import { Config } from "@core/config";
-
-export class CallbackError extends Error {
-  constructor(
-    readonly name: string,
-    readonly message: string,
-  ) {
-    super(message);
-  }
-}
-
-export const paramsError = () =>
-  new CallbackError("invalid-params", "code and redirectURI should be filled");
-export const exchangeError = (reason: string) =>
-  new CallbackError("failed-exchange", reason);
+import { exchangeError } from "@core/strategies/abstract";
 
 export const callbackHandler: RouteHandler = async ({
   request,

--- a/packages/auth/src/server/middleware/internal.ts
+++ b/packages/auth/src/server/middleware/internal.ts
@@ -1,30 +1,29 @@
 import { NextResponse } from "next/server";
 import { RouteHandler } from "@server/middleware";
 
-// Internal path to handle callback from the identity provider
-export const internalCallbackPath = "/__auth/callback" as const;
-export const callbackByStrategy = (strategy: string = "default") =>
-  `/__auth/callback/${strategy}` as const;
-
-// Internal path to fetch token from client components
-// `useSession` hook fetches token from this endpoint by extracting it from cookies.
-export const internalClientSessionPath = "/__auth/session" as const;
+/**
+ * Internal handler for fetching the session token from the client.
+ *
+ * @see {@link internalClientSessionPath}
+ */
 export const internalClientSessionHandler: RouteHandler = ({ request }) => {
   const tailorToken = request.cookies.get("tailor.token");
   return NextResponse.json({ token: tailorToken?.value || null });
 };
 
-// Internal path redirecting (through middleware) to `unauthorizedPath` set in ContextConfig
-// This is the path used in redirection caused by login guard in server components
-// The middleware that reads ContextConfig is in charge of redirecting to the `unauthorizedPath`
-// through this path when unauthorized users guarded in `getServerSession`.
-export const internalUnauthorizedPath = "/__auth/unauthorized" as const;
+/**
+ * Internal handler for unauthorized users.
+ *
+ * @see {@link internalUnauthorizedPath}
+ */
 export const internalUnauthroziedHandler: RouteHandler = ({ config }) =>
   NextResponse.redirect(config.appUrl(config.unauthorizedPath()));
 
-// Internal path to logout from client components
-// This function deletes the token from cookies and redirects to the login page.
-export const internalLogoutPath = "/__auth/logout" as const;
+/**
+ * Internal handler for logging out.
+ *
+ * @see {@link internalLogoutPath}
+ */
 export const internalLogoutHandler: RouteHandler = ({ request, config }) => {
   const redirectPath =
     request.nextUrl.searchParams.get("redirect_path") || config.loginPath();

--- a/packages/auth/src/tests/mocks.ts
+++ b/packages/auth/src/tests/mocks.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { Config } from "@core/config";
 import { Session } from "@core/types";
-import { internalClientSessionPath } from "@server/middleware/internal";
+import { internalClientSessionPath } from "@core/path";
 
 export const mockSession: Session = {
   access_token: "mockAccessToken",


### PR DESCRIPTION
# Background

I and Raj came across unexpected behaviour in writing component testing that is caused by `@tailor-platform/auth` package. 

The reason behind it is, that some packages unintentionally imports packages placed in `server` modules that depend on `next/server` package. That causes an error like `"next/server" is not found` in testing

# Changes

This pull request primarily involves refactoring and reorganizing the codebase for better structure and readability. The changes revolve around moving path-related constants and functions from the server middleware to a new `path.ts` file in the core directory. This makes the paths more accessible throughout the project. Additionally, the `CallbackError` class and related functions have been moved to the abstract strategies file.

Path-related changes:

* [`packages/auth/src/core/path.ts`](diffhunk://#diff-43b674d26e222d81993b815299765ba4a8b009c3da18113b4e1e90ec590e7c68R1-R18): New file created to hold all internal path-related constants and functions. This includes `internalCallbackPath`, `callbackByStrategy`, `internalClientSessionPath`, `internalUnauthorizedPath`, and `internalLogoutPath`.

* Various files (`packages/auth/src/adapters/apollo/link.ts`, `packages/auth/src/client/hooks.test.tsx`, `packages/auth/src/client/hooks.ts`, `packages/auth/src/core/loader.ts`, `packages/auth/src/core/strategies/minitailor.ts`, `packages/auth/src/core/strategies/sso.ts`, `packages/auth/src/server/index.ts`, `packages/auth/src/server/middleware.ts`, `packages/auth/src/server/middleware/callback.test.ts`, `packages/auth/src/tests/mocks.ts`): Updated imports to use the new `path.ts` file. [[1]](diffhunk://#diff-503f2c606711337604a5be8d820ac1b2ce28bb36b8a336f099803c1107e08d13R5-L6) [[2]](diffhunk://#diff-14dda08b1f46c69de796284f6b62e52ef480ff0ff760d479d87830bf812b3c47L9-R10) [[3]](diffhunk://#diff-1dfa41d6294f9c71b94051574daaf578d5b857d293c03c4f18553b3a8059f32aR3-R8) [[4]](diffhunk://#diff-8e986a4db2b146cea53c824b12f69e31b0f0e89605dc28a4c5bf8a7b70a09fd9L1-R1) [[5]](diffhunk://#diff-0930b04154634e876e843a0b9e37547ae1e62013aff478bc0343ad4608857a80L1-R3) [[6]](diffhunk://#diff-e2c6d19931678e76efce305cd3b25871f85169c7f9b4c4dd77ec6d13cf3ec9caL1-R3) [[7]](diffhunk://#diff-348e86486240957f431f2ba2280e4ee47a5e3d949313a825431479a556accc5bL8-R9) [[8]](diffhunk://#diff-2e090b44c7a207269efd9a4f21be7e8dfee962b26bb9e32fda4fb269a1eae3d7L5-R15) [[9]](diffhunk://#diff-51e47f158e8dd426e2b24df54f50fef01f16daa96f9d3f698ea8f51a733daf2dL5) [[10]](diffhunk://#diff-83e3aa9ce028057a2b86fa415ac9544c7981ad657b720b6a6dbe0c46475ba897L5-R5)

* [`packages/auth/src/server/middleware/internal.ts`](diffhunk://#diff-24559462a2cbfde34fcc77c85adac105ee3ca149f2e3a83d91c0397ba12db5b6L4-R26): Removed the path-related constants and functions, leaving only the middleware handlers.

Error-related changes:

* [`packages/auth/src/core/strategies/abstract.ts`](diffhunk://#diff-fdd28aa80995655ae8d74435ce10f1bbd8304cd903706bebd5a85cdf59f53dd5R115-R128): Added the `CallbackError` class and related functions (`paramsError`, `exchangeError`).

* [`packages/auth/src/server/middleware/callback.ts`](diffhunk://#diff-fdab66646daaaff4f963beac1e6762442f0527b24aa57617ebbace8154afcb84L5-R5): Removed the `CallbackError` class and related functions, and updated imports to use the new location in `abstract.ts`.

Other changes:

* [`packages/auth/package.json`](diffhunk://#diff-79fbe1d958aec3ec2b3d46cdc5b9b34cd834f48550895ce9484f10c0f77a4a8fL3-R3): Updated the version number.
