### PR TITLE
fix(ds): fix test error

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -67,6 +67,7 @@
     "react": "^18.2.0",
     "tsup": "^8.0.1",
     "typescript": "^5.3.3",
+    "vite-tsconfig-paths": "^4.3.1",
     "vitest": "^1.0.2",
     "zod": "^3.22.4"
   },

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/Density/Density.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Density/Density.tsx
@@ -13,11 +13,8 @@ import {
   DensityTableState,
   DensityProps,
 } from "../types";
-import {
-  RadioGroup,
-  type RadioGroupOption,
-} from "@components/composite/RadioGroup";
-import { Box } from "@components/patterns/Box";
+import { RadioGroup, type RadioGroupOption } from "../../RadioGroup";
+import { Box } from "../../../patterns/Box";
 
 export const Density = forwardRef(
   (props: DensityProps, ref: ForwardedRef<HTMLDivElement>) => {

--- a/packages/design-systems/src/components/composite/Datagrid/Density/Density.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Density/Density.tsx
@@ -13,8 +13,11 @@ import {
   DensityTableState,
   DensityProps,
 } from "../types";
-import { RadioGroup, type RadioGroupOption } from "../../RadioGroup";
-import { Box } from "../../../patterns/Box";
+import {
+  RadioGroup,
+  type RadioGroupOption,
+} from "@components/composite/RadioGroup";
+import { Box } from "@components/patterns/Box";
 
 export const Density = forwardRef(
   (props: DensityProps, ref: ForwardedRef<HTMLDivElement>) => {

--- a/packages/design-systems/vite.config.js
+++ b/packages/design-systems/vite.config.js
@@ -1,8 +1,9 @@
+import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
   test: {
     environment: "jsdom",
     globals: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
+      vite-tsconfig-paths:
+        specifier: ^4.3.1
+        version: 4.3.1(typescript@5.3.3)(vite@5.1.4)
       vitest:
         specifier: ^1.0.2
         version: 1.0.2(@types/node@18.19.2)(jsdom@23.0.1)
@@ -13875,7 +13878,7 @@ packages:
       '@babel/plugin-transform-nullish-coalescing-operator': 7.23.4(@babel/core@7.23.7)
       '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.23.7)
       '@babel/plugin-transform-private-methods': 7.23.3(@babel/core@7.23.7)
-      '@babel/preset-env': 7.23.5(@babel/core@7.23.5)
+      '@babel/preset-env': 7.23.5(@babel/core@7.23.7)
       '@babel/preset-flow': 7.23.3(@babel/core@7.23.7)
       '@babel/preset-typescript': 7.23.3(@babel/core@7.23.7)
       '@babel/register': 7.22.15(@babel/core@7.23.7)


### PR DESCRIPTION
# Background

test has broken
https://github.com/tailor-platform/frontend-packages/actions/runs/8685164594/job/23814078277
<!-- Why is this change necessary, how it came to be? -->

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request mainly focuses on the `@tailor-platform/design-systems` package, with updates to both the package version and component imports. The most significant changes are the increment of the package version from `0.24.0` to `0.24.1` and the adjustment of import paths in the `Density.tsx` component.

Here are the key changes:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The package version has been updated from `0.24.0` to `0.24.1`. This indicates a minor update or patch to the package.

* [`packages/design-systems/src/components/composite/Datagrid/Density/Density.tsx`](diffhunk://#diff-38caeba8142dd91711c6e10f14b4f518a23ea61bec45f9ed1227a5e01abd7022L16-R17): The import paths for the `RadioGroup` and `Box` components have been updated. Previously, these components were imported from `@components/composite/RadioGroup` and `@components/patterns/Box` respectively. Now, they are being imported from relative paths, i.e., `../../RadioGroup` and `../../../patterns/Box`. This change suggests a reorganization of the codebase or a move towards using relative paths for component imports.