### PR TITLE
chore(auth): drop ESM support

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -3,28 +3,23 @@
   "version": "0.6.4-preview.2",
   "private": false,
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     "./core": {
       "types": "./dist/core/index.d.ts",
-      "import": "./dist/core/index.mjs",
-      "require": "./dist/core/index.js"
+      "default": "./dist/core/index.js"
     },
     "./client": {
       "types": "./dist/client/index.d.ts",
-      "import": "./dist/client/index.mjs",
-      "require": "./dist/client/index.js"
+      "default": "./dist/client/index.js"
     },
     "./server": {
       "types": "./dist/server/index.d.ts",
-      "import": "./dist/server/index.mjs",
-      "require": "./dist/server/index.js"
+      "default": "./dist/server/index.js"
     },
     "./adapters/apollo": {
       "types": "./dist/adapters/apollo/index.d.ts",
-      "import": "./dist/adapters/apollo/index.mjs",
-      "require": "./dist/adapters/apollo/index.js"
+      "default": "./dist/adapters/apollo/index.js"
     }
   },
   "files": [

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.4-preview.2",
+  "version": "0.6.4-preview.3",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.4-preview.3",
+  "version": "0.6.5",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.6.4",
+  "version": "0.6.4-preview.2",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/auth/tsup.config.ts
+++ b/packages/auth/tsup.config.ts
@@ -11,6 +11,9 @@ const devOpts =
     : {};
 
 export default defineConfig({
+  // explictly use CommonJS as build format here
+  // because auth package depends on @apollo/client that has no ESM support
+  format: ["cjs"],
   entry: [
     "src/client/index.ts",
     "src/server/index.ts",
@@ -19,7 +22,6 @@ export default defineConfig({
   ],
   clean: true,
   minify: true,
-  format: ["cjs", "esm"],
   dts: true,
   external: ["react", "@apollo/client"],
   ...devOpts,


### PR DESCRIPTION
# Background

Due to lack of ESM support by apollo-client, component test on IMA raises an error with the message below.

```
Error: Directory import '/Users/seiya/Devs/ima/node_modules/.pnpm/@tailor-platform+auth@0.6.4-preview.1_@apollo+client@3.9.5_next@14.1.4/node_modules/@apollo/client/link/context' is not supported resolving ES modules imported from /Users/seiya/Devs/ima/node_modules/.pnpm/@tailor-platform+auth@0.6.4-preview.1_@apollo+client@3.9.5_next@14.1.4/node_modules/@tailo
r-platform/auth/dist/chunk-UXJCZNRD.mjs
Did you mean to import @apollo+client@3.9.5_@types+react@18.2.33_graphql@16.8.1_react-dom@18.2.0_react@18.2.0/node_modules/@apollo/client/link/context/context.cjs?
```

This is caused by module design that auth package internally imports apollo-client as CommonJS, but applications import auth package as ESM. Vitest does not allow us to resolve package imports with mix of ESM and CJS.

# Changes

This pull request primarily updates the `packages/auth` package. The changes include an update to the version of the package, a switch to using CommonJS as the build format due to a dependency that doesn't support ESM, and a modification of the `package.json` file to reflect these changes.

Package version update:

* [`packages/auth/package.json`](diffhunk://#diff-79fbe1d958aec3ec2b3d46cdc5b9b34cd834f48550895ce9484f10c0f77a4a8fL3-R22): The version of the package has been updated from `0.6.4` to `0.6.5`.

Switch to CommonJS:

* [`packages/auth/tsup.config.ts`](diffhunk://#diff-ba0fb9c0541f00abb5982573c6d8aa48fa65caaf29ddbcf3a141d6c53f896006R14-R16): The build format has been explicitly set to use CommonJS because the auth package depends on `@apollo/client` which does not support ESM.

Modifications to `package.json`:

* [`packages/auth/package.json`](diffhunk://#diff-79fbe1d958aec3ec2b3d46cdc5b9b34cd834f48550895ce9484f10c0f77a4a8fL3-R22): The `module` field has been removed and the `import` and `require` fields have been replaced by `default` in the `exports` section. This change reflects the switch to using CommonJS.
