### PR TITLE
fix(ds): fix initial state

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx
@@ -52,7 +52,7 @@ export const ExportFeature: TableFeature = {
   getInitialState: (state): ExportTableState => {
     return {
       exportOptions: {
-        enableCsvExport: true,
+        enableCsvExport: false,
       },
       exportOpen: false,
       ...state,
@@ -60,7 +60,7 @@ export const ExportFeature: TableFeature = {
   },
   getDefaultOptions: (): ExportOptions => {
     return {
-      enableCsvExport: true,
+      enableCsvExport: false,
     } as ExportOptions;
   },
 

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -33,7 +33,7 @@ export const useDataGrid = <TData extends RowLike>({
   rowSelection,
   pageSizeOptions = [],
   enableDensity = false,
-  exportOptions = { enableCsvExport: true },
+  exportOptions = { enableCsvExport: false },
 }: UseDataGridProps<TData>): DataGridInstance<TData> => {
   const { pageIndex = 0, pageSize = 50 } = pagination || {};
   const [columnPinningState, setColumnPinningState] =


### PR DESCRIPTION
# Background

<!-- Why is this change necessary, how it came to be? -->
The initial value of export is true, and export is displayed if nothing is set.

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request primarily focuses on changes in the `design-systems` package. The key changes involve updating the package version and disabling the CSV export feature in the `Datagrid` component.

Key Changes:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The package version has been updated from 0.25.0 to 0.25.1.

CSV Export Feature Changes:

* [`packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx`](diffhunk://#diff-e930d60896112c0ec1edbf040b21449937b2a2c4ba0056e55ed7a33dd8b700a4L55-R63): The `enableCsvExport` option in the `ExportFeature` constant has been set to `false`, disabling the CSV export feature by default.
* [`packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx`](diffhunk://#diff-14aa5328e3b002bc6281f392fbba405593aa8ee29bc6f844d5f2c1191cefc377L36-R36): The default value of `exportOptions` in the `useDataGrid` function has been changed to `{ enableCsvExport: false }`, which also disables the CSV export feature.