### PR TITLE
fix(ds): fix default filter

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
@@ -408,6 +408,7 @@ export const FilterRow = <TData extends Record<string, unknown>>(
             onValueChange={(e: ValueChangeDetails<CollectionItem>) =>
               onChangeValue(e.value)
             }
+            value={[`${currentFilter.value}`]}
             data-testid="select-input-value"
           >
             <Select.Control className={classes.control}>


### PR DESCRIPTION
# Background

<!-- Why is this change necessary, how it came to be? -->
Initial value is not entered when type is boolean in defaultFilter

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request primarily focuses on the `packages/design-systems` package. The two main changes involve updating the version of the package and modifying the `FilterRow` component to include a value property.

Package version update:

* [`packages/design_systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the package has been updated from `0.26.0` to `0.26.1`. This is typically done after making changes to the package to indicate a new version of the package is available.

Component modification:

* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx`](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dR411): In the `FilterRow` component, a `value` property has been added to the `Select` component. This sets the initial value of the select component to the `currentFilter.value`.