### PR TITLE
fix(ds): fix boolean in datagrid custom filter

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
@@ -651,7 +651,7 @@ describe(
       //Check filters
       await waitFor(() => {
         //Wait for the useEffect to update the filters
-        expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+        expect(currentFilters).toEqual({ isCreditCard: { eq: true } });
       });
     });
 
@@ -682,7 +682,7 @@ describe(
       //Check filters
       await waitFor(() => {
         //Wait for the useEffect to update the filters
-        expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+        expect(currentFilters).toEqual({ isCreditCard: { eq: true } });
       });
 
       //Add new filter row
@@ -737,7 +737,7 @@ describe(
       await waitFor(() => {
         //Wait for the useEffect to update the filters
         expect(currentFilters).toEqual({
-          isCreditCard: { eq: "true" },
+          isCreditCard: { eq: true },
           and: {
             status: { eq: "success" },
             and: {
@@ -781,7 +781,7 @@ describe(
       //Check filters
       await waitFor(() => {
         //Wait for the useEffect to update the filters
-        expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+        expect(currentFilters).toEqual({ isCreditCard: { eq: true } });
       });
 
       //Add new filter row
@@ -836,7 +836,7 @@ describe(
       await waitFor(() => {
         //Wait for the useEffect to update the filters
         expect(currentFilters).toEqual({
-          isCreditCard: { eq: "true" },
+          isCreditCard: { eq: true },
           or: {
             status: { eq: "success" },
             or: {
@@ -880,7 +880,7 @@ describe(
       //Check filters
       await waitFor(() => {
         //Wait for the useEffect to update the filters
-        expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+        expect(currentFilters).toEqual({ isCreditCard: { eq: true } });
       });
 
       //Add new filter row
@@ -899,7 +899,7 @@ describe(
       await waitFor(() => {
         //Wait for the useEffect to update the filters
         expect(currentFilters).toEqual({
-          isCreditCard: { eq: "true" },
+          isCreditCard: { eq: true },
           and: { status: { eq: "success" } },
         });
       });
@@ -910,7 +910,7 @@ describe(
       //Check filters
       await waitFor(() => {
         //Wait for the useEffect to update the filters
-        expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+        expect(currentFilters).toEqual({ isCreditCard: { eq: true } });
       });
     });
 
@@ -941,7 +941,7 @@ describe(
       //Check filters
       await waitFor(() => {
         //Wait for the useEffect to update the filters
-        expect(currentFilters).toEqual({ isCreditCard: { eq: "true" } });
+        expect(currentFilters).toEqual({ isCreditCard: { eq: true } });
       });
 
       //Add new filter row
@@ -960,7 +960,7 @@ describe(
       await waitFor(() => {
         //Wait for the useEffect to update the filters
         expect(currentFilters).toEqual({
-          isCreditCard: { eq: "true" },
+          isCreditCard: { eq: true },
           and: { status: { eq: "success" } },
         });
       });

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
@@ -338,7 +338,7 @@ export const FilterRow = <TData extends Record<string, unknown>>(
             positioning={{ sameWidth: true }}
             closeOnSelect
             width={180}
-            value={[currentFilter.value]}
+            value={[currentFilter.value.toString()]}
             onValueChange={(e: ValueChangeDetails<CollectionItem>) =>
               onChangeValue(e.value)
             }
@@ -355,7 +355,7 @@ export const FilterRow = <TData extends Record<string, unknown>>(
                   <span>
                     {currentFilter.value !== ""
                       ? selectedColumnObject?.meta?.enumType?.[
-                          currentFilter.value
+                          currentFilter.value.toString()
                         ]
                       : inputValuePlaceHolder}
                   </span>
@@ -408,7 +408,7 @@ export const FilterRow = <TData extends Record<string, unknown>>(
             onValueChange={(e: ValueChangeDetails<CollectionItem>) =>
               onChangeValue(e.value)
             }
-            value={[`${currentFilter.value}`]}
+            value={[currentFilter.value.toString()]}
             data-testid="select-input-value"
           >
             <Select.Control className={classes.control}>
@@ -470,7 +470,7 @@ export const FilterRow = <TData extends Record<string, unknown>>(
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 onChangeValue(e.target.value);
               }}
-              value={[currentFilter.value]}
+              value={[currentFilter.value.toString()]}
               type={selectedColumnObject?.meta?.type || "text"} //This input element is used for date, number and text type (for enum and boolean, we use select element above instead)
               maxLength={50}
             />

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/types.ts
@@ -10,7 +10,7 @@ export type ValueChangeDetails<T extends CollectionItem = CollectionItem> = {
 
 export type FilterRowState = {
   column: string;
-  value: string;
+  value: string | boolean;
   condition: string;
   jointCondition?: string;
   isSystem: boolean;


### PR DESCRIPTION
# Background

<!-- Why is this change necessary, how it came to be? -->
- Custom Filter is broken when boolean

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request primarily focuses on improving the handling of boolean values in the `CustomFilter` and `FilterRow` components within the `packages/design-systems` package. The changes ensure that boolean values are properly processed and displayed. Additionally, the version of the `@tailor-platform/design-systems` package has been bumped up.

Here are the most important changes:

Version Bump:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the `@tailor-platform/design-systems` package has been updated from `0.26.2` to `0.26.3`.

Boolean Value Handling:

* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.tsx`](diffhunk://#diff-ba24f0046bbb65e4b433f2c85c6fc8864b22af8057ca5adada1149daaab8e17cL381-R408): The `addToGraphQLQueryFilterRecursively` function now handles boolean values correctly by checking if the value is `"true"` or `"false"` and converting it to a boolean.
* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.tsx`](diffhunk://#diff-ba24f0046bbb65e4b433f2c85c6fc8864b22af8057ca5adada1149daaab8e17cL415-R430): The `isExistCurrentState` boolean has been introduced to check if the current state exists, including when the value is `false`.
* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx`](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL341-R341): The `value` prop of multiple components now uses `currentFilter.value.toString()` to ensure boolean values are correctly converted to strings. [[1]](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL341-R341) [[2]](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL358-R358) [[3]](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL411-R411) [[4]](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL473-R473)
* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/types.ts`](diffhunk://#diff-88ff2502b5476ac89dce925bcb5c2bdb1380494b9009a121ae28d06ba107f012L13-R13): The `value` field in the `FilterRowState` type has been updated to accept both `string` and `boolean` types.

Test Adjustments:

* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx`](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL654-R654): Multiple test cases have been updated to expect a boolean `true` instead of the string `"true"` for the `isCreditCard` filter. [[1]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL654-R654) [[2]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL685-R685) [[3]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL740-R740) [[4]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL784-R784) [[5]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL839-R839) [[6]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL883-R883) [[7]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL902-R902) [[8]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL913-R913) [[9]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL944-R944) [[10]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL963-R963)