### PR TITLE
fix(auth): cache session tokens for custom apollo-link

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/src/adapters/apollo/link.ts
+++ b/packages/auth/src/adapters/apollo/link.ts
@@ -1,4 +1,4 @@
-import { from, HttpLink, ServerError } from "@apollo/client";
+import { from, HttpLink, makeVar, ServerError } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
 import { onError } from "@apollo/client/link/error";
 import { Config } from "@core/config";
@@ -48,10 +48,9 @@ export const authenticatedHttpLink = (config: Config) =>
           return { authorization: headers.authorization };
         }
 
-        const rawResp = await fetch(config.appUrl(internalClientSessionPath));
-        const session = (await rawResp.json()) as SessionResult;
-        if (session.token) {
-          return { authorization: `Bearer ${session.token}` };
+        const sessionToken = await fetchSessionToken(config);
+        if (sessionToken) {
+          return { authorization: `Bearer ${sessionToken}` };
         }
 
         return {};
@@ -82,3 +81,22 @@ export const authenticatedHttpLink = (config: Config) =>
       uri: config.apiUrl("/query"),
     }),
   ]);
+
+/**
+ * fetchSessionToken fetches the session token from the server.
+ * If the token is already stored in the cache, it returns the token on memory to avoid unnecessary fetch.
+ */
+const fetchSessionToken = async (config: Config) => {
+  const currentSeessionToken = sessionToken();
+  if (currentSeessionToken.token) {
+    return currentSeessionToken.token;
+  }
+
+  const rawResp = await fetch(config.appUrl(internalClientSessionPath));
+  const session = (await rawResp.json()) as SessionResult;
+  const { token } = sessionToken(session);
+  return token;
+};
+const sessionToken = makeVar<SessionResult>({
+  token: null,
+});


### PR DESCRIPTION
# Background

Auth package makes requests to `__auth/session` at every time when apollo-client makes GQL requests, but this is not unexpected behaviour.

# Changes

Let it cache the token as a reactive variable once after the session token is fetched.
