### PR TITLE
fix(ds): Fix css in dataGrid

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -102,7 +102,6 @@ export const DataGrid = <TData extends Record<string, unknown>>(
       position: isHeader || isPinned ? "sticky" : "relative",
       opacity: isPinned ? 0.95 : 1,
       zIndex: isPinned ? 1 : 0,
-      backgroundColor: isHeader || isPinned ? "bg.default" : "inherit",
     };
   };
 

--- a/packages/design-systems/src/theme/slot-recipes/datagrid.ts
+++ b/packages/design-systems/src/theme/slot-recipes/datagrid.ts
@@ -72,6 +72,7 @@ export const datagrid = defineSlotRecipe({
       zIndex: 0,
     },
     tableData: {
+      backgroundColor: "bg.default",
       borderLeft: "none",
       borderBottom: "none",
       borderWidth: "0.5px",


### PR DESCRIPTION
# Background

Datagrid pinned columns has unexpected transparent background
https://tailor.atlassian.net/browse/FL-174

# Changes

before 

https://github.com/tailor-platform/frontend-packages/assets/28993018/4f450682-04c6-42fe-9903-fad10c1877b5

after

https://github.com/tailor-platform/frontend-packages/assets/28993018/746fb7c9-ecea-414f-9a20-5b3b42c6180b


The backgroundColor defined in getCommonPinningStyles was not being applied; I checked the datagrid recipe and fixed it because the backgroundColor was not set.