### PR TITLE
fix(ds): add omit option for export csv

### DIFF
--- a/apps/storybook/src/stories/datagrid/DataGridExportStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridExportStory.tsx
@@ -31,6 +31,7 @@ export const DataGridExportStory = ({
       setFilterChange(filter, originData, setData);
     },
     exportOptions: { enableCsvExport },
+    exportRejectColumns: ["updatedAt"]
   });
 
   return (

--- a/apps/storybook/src/stories/datagrid/DataGridExportStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridExportStory.tsx
@@ -31,7 +31,7 @@ export const DataGridExportStory = ({
       setFilterChange(filter, originData, setData);
     },
     exportOptions: { enableCsvExport },
-    exportRejectColumns: ["updatedAt"]
+    exportRejectColumns: ["updatedAt"],
   });
 
   return (

--- a/apps/storybook/src/stories/datagrid/DataGridExportStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridExportStory.tsx
@@ -30,8 +30,7 @@ export const DataGridExportStory = ({
     onFilterChange: (filter) => {
       setFilterChange(filter, originData, setData);
     },
-    exportOptions: { enableCsvExport },
-    exportRejectColumns: ["updatedAt"],
+    exportOptions: { enableCsvExport, omit: ["updatedAt"] },
   });
 
   return (

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -137,12 +137,7 @@ export const DataGrid = <TData extends Record<string, unknown>>(
         {table.enableHiding && (
           <HideShow
             allColumnsHandler={table.getToggleAllColumnsVisibilityHandler}
-            columns={
-              table.getAllLeafColumns() as ColumnTanstak<
-                Record<string, unknown>,
-                unknown
-              >[]
-            }
+            columns={table.getAllLeafColumns()}
             localization={localization}
             hideShowOpen={hideShowOpen}
             setHideShowOpen={table.setHideShowOpen}

--- a/packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx
@@ -88,7 +88,7 @@ export const ExportFeature: TableFeature = {
   },
   getDefaultOptions: (): ExportOptions => {
     return {
-      enableCsvExport: false,
+      exportRejectColumns: [],
     } as ExportOptions;
   },
 
@@ -104,6 +104,7 @@ export const ExportFeature: TableFeature = {
       return false;
     };
     table.exportCsv = () => {
+      const reject = table.options.exportRejectColumns
       const csvConfig = mkConfig({
         fieldSeparator: ",",
         filename: "sample", // export file name (without .csv)
@@ -116,6 +117,7 @@ export const ExportFeature: TableFeature = {
         const original = row.original;
         const visibleColumnRow: VisibleColumnRow = {};
         columns.forEach((column) => {
+          if(reject?.includes(column.id)) return;
           const header = (column.columnDef?.header as string) || column.id;
           if ("accessorKey" in column.columnDef) {
             visibleColumnRow[header] = original[column.columnDef.accessorKey];

--- a/packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx
@@ -83,15 +83,17 @@ type VisibleColumnRow = {
   [key: string]: unknown;
 };
 
+export const defaultExportOptions = {
+  enableCsvExport: false,
+  omit: undefined,
+};
+
 export const ExportFeature: TableFeature = {
   getInitialState: <TData extends Record<string, string>>(
     state: InitialTableState | undefined,
   ): ExportTableState<TData> => {
     return {
-      exportOptions: {
-        enableCsvExport: false,
-        omit: undefined,
-      },
+      exportOptions: defaultExportOptions,
       exportOpen: false,
       ...state,
     };
@@ -100,10 +102,7 @@ export const ExportFeature: TableFeature = {
     TData extends Record<string, string>,
   >(): ExportOptions<TData> => {
     return {
-      exportOptions: {
-        enableCsvExport: false,
-        omit: undefined,
-      },
+      exportOptions: defaultExportOptions,
     } as ExportOptions<TData>;
   },
 

--- a/packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx
@@ -88,7 +88,10 @@ export const ExportFeature: TableFeature = {
   },
   getDefaultOptions: (): ExportOptions => {
     return {
-      exportRejectColumns: [],
+      exportOptions: {
+        enableCsvExport: false,
+        omit: [],
+      },
     } as ExportOptions;
   },
 
@@ -104,7 +107,7 @@ export const ExportFeature: TableFeature = {
       return false;
     };
     table.exportCsv = () => {
-      const reject = table.options.exportRejectColumns;
+      const reject = table.options.exportOptions?.omit;
       const csvConfig = mkConfig({
         fieldSeparator: ",",
         filename: "sample", // export file name (without .csv)

--- a/packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx
@@ -104,7 +104,7 @@ export const ExportFeature: TableFeature = {
       return false;
     };
     table.exportCsv = () => {
-      const reject = table.options.exportRejectColumns
+      const reject = table.options.exportRejectColumns;
       const csvConfig = mkConfig({
         fieldSeparator: ",",
         filename: "sample", // export file name (without .csv)
@@ -117,7 +117,7 @@ export const ExportFeature: TableFeature = {
         const original = row.original;
         const visibleColumnRow: VisibleColumnRow = {};
         columns.forEach((column) => {
-          if(reject?.includes(column.id)) return;
+          if (reject?.includes(column.id)) return;
           const header = (column.columnDef?.header as string) || column.id;
           if ("accessorKey" in column.columnDef) {
             visibleColumnRow[header] = original[column.columnDef.accessorKey];

--- a/packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx
@@ -109,7 +109,6 @@ export const ExportFeature: TableFeature = {
   createTable: <TData extends Record<string, unknown>>(
     table: Table<TData>,
   ): void => {
-    table.initialState;
     table.setExportOpen = makeStateUpdater("exportOpen", table);
     table.getEnableExport = () => {
       const exportOptions = table.getState().exportOptions;
@@ -119,7 +118,7 @@ export const ExportFeature: TableFeature = {
       return false;
     };
     table.exportCsv = () => {
-      const reject = table.getState().exportOptions?.omit;
+      const omit = table.getState().exportOptions?.omit;
       const csvConfig = mkConfig({
         fieldSeparator: ",",
         filename: "sample", // export file name (without .csv)
@@ -132,7 +131,7 @@ export const ExportFeature: TableFeature = {
         const original = row.original;
         const visibleColumnRow: VisibleColumnRow = {};
         columns.forEach((column) => {
-          if (reject?.includes(column.id)) return;
+          if (omit?.includes(column.id)) return;
           const header = (column.columnDef?.header as string) || column.id;
           if ("accessorKey" in column.columnDef) {
             visibleColumnRow[header] = original[column.columnDef.accessorKey];

--- a/packages/design-systems/src/components/composite/Datagrid/Export/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/Export/types.ts
@@ -10,7 +10,9 @@ export interface ExportTableState {
   exportOpen: boolean;
 }
 
-export interface ExportOptions {}
+export interface ExportOptions {
+  exportRejectColumns?: string[];
+}
 
 export interface ExportInstance {
   setExportOpen: (updater: Updater<boolean>) => void;

--- a/packages/design-systems/src/components/composite/Datagrid/Export/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/Export/types.ts
@@ -3,6 +3,7 @@ import type { Localization } from "..";
 
 export type ExportState = {
   enableCsvExport?: boolean;
+  omit?: string[];
 };
 
 export interface ExportTableState {
@@ -11,7 +12,7 @@ export interface ExportTableState {
 }
 
 export interface ExportOptions {
-  exportRejectColumns?: string[];
+  exportOptions: ExportState;
 }
 
 export interface ExportInstance {

--- a/packages/design-systems/src/components/composite/Datagrid/Export/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/Export/types.ts
@@ -1,18 +1,18 @@
 import type { Updater } from "@tanstack/table-core";
 import type { Localization } from "..";
 
-export type ExportState = {
+export type ExportState<TData extends Record<string, unknown>> = {
   enableCsvExport?: boolean;
-  omit?: string[];
+  omit?: [keyof TData];
 };
 
-export interface ExportTableState {
-  exportOptions: ExportState;
+export interface ExportTableState<TData extends Record<string, unknown>> {
+  exportOptions: ExportState<TData>;
   exportOpen: boolean;
 }
 
-export interface ExportOptions {
-  exportOptions: ExportState;
+export interface ExportOptions<TData extends Record<string, unknown>> {
+  exportOptions: ExportState<TData>;
 }
 
 export interface ExportInstance {
@@ -21,8 +21,8 @@ export interface ExportInstance {
   exportCsv: () => void;
 }
 
-export type ExportProps = {
-  exportOptions?: ExportState;
+export type ExportProps<TData extends Record<string, unknown>> = {
+  exportOptions?: ExportState<TData>;
   localization: Localization;
   exportCsv: () => void;
   exportOpen: boolean;

--- a/packages/design-systems/src/components/composite/Datagrid/type.d.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/type.d.ts
@@ -29,12 +29,12 @@ declare module "@tanstack/react-table" {
     extends CustomFilterTableState,
       HideShowTableState,
       DensityTableState,
-      ExportTableState {}
-  interface TableOptionsResolved
+      ExportTableState<TData> {}
+  interface TableOptionsResolved<TData extends Record<string, unknown>>
     extends CustomFilterOptions,
       HideShowOptions,
       DensityOptions,
-      ExportOptions {}
+      ExportOptions<TData> {}
   interface Table
     extends CustomFilterInstance,
       HideShowInstance,

--- a/packages/design-systems/src/components/composite/Datagrid/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/types.ts
@@ -62,7 +62,6 @@ export type UseDataGridProps<TData> = {
   exportOptions?: ExportState;
   enableSorting?: boolean;
   onSortChange?: (sorting: Order | undefined) => void;
-  exportRejectColumns?: string[];
 };
 
 export type Column<TData> = {

--- a/packages/design-systems/src/components/composite/Datagrid/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/types.ts
@@ -33,7 +33,7 @@ export interface DataGridInstance<
   onSortChange?: (sorting: Order | undefined) => void;
 }
 
-export type UseDataGridProps<TData> = {
+export type UseDataGridProps<TData extends Record<string, unknown>> = {
   data: TData[];
   columns: ColumnDef<TData>[];
   enablePagination?: boolean;
@@ -59,7 +59,7 @@ export type UseDataGridProps<TData> = {
   setColumnPinning?: (updater: Updater<ColumnPinningState>) => void;
   pageSizeOptions?: number[];
   enableDensity?: boolean;
-  exportOptions?: ExportState;
+  exportOptions?: ExportState<TData>;
   enableSorting?: boolean;
   onSortChange?: (sorting: Order | undefined) => void;
 };

--- a/packages/design-systems/src/components/composite/Datagrid/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/types.ts
@@ -62,6 +62,7 @@ export type UseDataGridProps<TData> = {
   exportOptions?: ExportState;
   enableSorting?: boolean;
   onSortChange?: (sorting: Order | undefined) => void;
+  exportRejectColumns?: string[];
 };
 
 export type Column<TData> = {

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -38,7 +38,7 @@ export const useDataGrid = <TData extends RowLike>({
   rowSelection,
   pageSizeOptions = [],
   enableDensity = false,
-  exportOptions = { enableCsvExport: false, omit: [] },
+  exportOptions = { enableCsvExport: false, omit: undefined },
   enableSorting = false,
   onSortChange,
 }: UseDataGridProps<TData>): DataGridInstance<TData> => {

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -38,10 +38,9 @@ export const useDataGrid = <TData extends RowLike>({
   rowSelection,
   pageSizeOptions = [],
   enableDensity = false,
-  exportOptions = { enableCsvExport: false },
+  exportOptions = { enableCsvExport: false, omit: [] },
   enableSorting = false,
   onSortChange,
-  exportRejectColumns,
 }: UseDataGridProps<TData>): DataGridInstance<TData> => {
   const { pageIndex = 0, pageSize = 50 } = pagination || {};
   const [columnPinningState, setColumnPinningState] =
@@ -144,7 +143,7 @@ export const useDataGrid = <TData extends RowLike>({
     getSortedRowModel:
       enableSorting && !manualPagination ? getSortedRowModel() : undefined,
     sortDescFirst: true,
-    exportRejectColumns,
+    exportOptions,
     ...sortingConfigs,
   });
 

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -10,7 +10,7 @@ import {
 import { Checkbox } from "../../Checkbox";
 import { type DataGridInstance, type UseDataGridProps } from "./types";
 import { DensityFeature } from "./Density/Density";
-import { ExportFeature } from "./Export/Export";
+import { ExportFeature, defaultExportOptions } from "./Export/Export";
 import { HideShowFeature } from "./ColumnFeature/HideShow";
 import { CustomFilterFeature } from "./SearchFilter/CustomFilter";
 
@@ -38,7 +38,7 @@ export const useDataGrid = <TData extends RowLike>({
   rowSelection,
   pageSizeOptions = [],
   enableDensity = false,
-  exportOptions = { enableCsvExport: false, omit: undefined },
+  exportOptions = defaultExportOptions,
   enableSorting = false,
   onSortChange,
 }: UseDataGridProps<TData>): DataGridInstance<TData> => {

--- a/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx
@@ -41,6 +41,7 @@ export const useDataGrid = <TData extends RowLike>({
   exportOptions = { enableCsvExport: false },
   enableSorting = false,
   onSortChange,
+  exportRejectColumns,
 }: UseDataGridProps<TData>): DataGridInstance<TData> => {
   const { pageIndex = 0, pageSize = 50 } = pagination || {};
   const [columnPinningState, setColumnPinningState] =
@@ -143,6 +144,7 @@ export const useDataGrid = <TData extends RowLike>({
     getSortedRowModel:
       enableSorting && !manualPagination ? getSortedRowModel() : undefined,
     sortDescFirst: true,
+    exportRejectColumns,
     ...sortingConfigs,
   });
 


### PR DESCRIPTION
# Background

<!-- Why is this change necessary, how it came to be? -->
We need a setting to prevent certain columns from being exported.

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request primarily introduces the `exportRejectColumns` feature to the `DataGrid` component in the `design-systems` package. This feature allows certain columns to be excluded from the CSV export functionality of the `DataGrid` component. The changes are spread across multiple files, with the most significant changes involving the addition of the `exportRejectColumns` property to various interfaces and functions.

Key changes include:

Addition of `exportRejectColumns`:

* [`packages/design-systems/src/components/composite/Datagrid/Export/types.ts`](diffhunk://#diff-0733f1dff82f019dba1799eef6c2d2ff78cf7561f95afc38c024ff1e56cfbc94L13-R15): Added `exportRejectColumns` as an optional property to the `ExportOptions` interface. This property is an array of strings, each string being the id of a column to be excluded from the export.
* [`packages/design-systems/src/components/composite/Datagrid/types.ts`](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917R65): Added `exportRejectColumns` as an optional property to the `UseDataGridProps` type.
* [`packages/design-systems/src/components/composite/Datagrid/useDataGrid.tsx`](diffhunk://#diff-14aa5328e3b002bc6281f392fbba405593aa8ee29bc6f844d5f2c1191cefc377R44): Added `exportRejectColumns` as a parameter to the `useDataGrid` function and passed it to the `useTable` function call. [[1]](diffhunk://#diff-14aa5328e3b002bc6281f392fbba405593aa8ee29bc6f844d5f2c1191cefc377R44) [[2]](diffhunk://#diff-14aa5328e3b002bc6281f392fbba405593aa8ee29bc6f844d5f2c1191cefc377R147)

Modification of export functionality:

* [`packages/design-systems/src/components/composite/Datagrid/Export/Export.tsx`](diffhunk://#diff-e930d60896112c0ec1edbf040b21449937b2a2c4ba0056e55ed7a33dd8b700a4L91-R91): Modified the `ExportFeature` to include `exportRejectColumns` in the default options and to exclude the specified columns during CSV export. [[1]](diffhunk://#diff-e930d60896112c0ec1edbf040b21449937b2a2c4ba0056e55ed7a33dd8b700a4L91-R91) [[2]](diffhunk://#diff-e930d60896112c0ec1edbf040b21449937b2a2c4ba0056e55ed7a33dd8b700a4R107) [[3]](diffhunk://#diff-e930d60896112c0ec1edbf040b21449937b2a2c4ba0056e55ed7a33dd8b700a4R120)
* [`apps/storybook/src/stories/datagrid/DataGridExportStory.tsx`](diffhunk://#diff-f926531f6aaee7c85253918c085ce2b0f787d1b178993057775451df77ce7390R34): Added `"updatedAt"` to the `exportRejectColumns` in the `DataGridExportStory` component.