### PR TITLE
fix(ds): add type for Order

### DIFF
--- a/apps/storybook/src/stories/datagrid/DataGridManualSortingStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridManualSortingStory.tsx
@@ -22,7 +22,7 @@ export const DataGridManualSortingStory = ({
   pageSize = 8,
 }: DataGridManualSortingStoryProps) => {
   const [data, setData] = useState<Payment[]>(originData.slice(0, pageSize));
-  const [sorting, setSorting] = useState<Order | undefined>(undefined);
+  const [sorting, setSorting] = useState<Order<Payment> | undefined>(undefined);
   const [ps, setPs] = useState(pageSize);
 
   const table = useDataGrid({

--- a/apps/storybook/src/stories/datagrid/utils.ts
+++ b/apps/storybook/src/stories/datagrid/utils.ts
@@ -276,7 +276,7 @@ export const setFilterChange = (
 
 export const setSortChange = (
   data: Payment[],
-  sorting: Order | undefined,
+  sorting: Order<Payment> | undefined,
 ): Payment[] => {
   if (!sorting) return data;
   return [...data].sort((a, b) => {

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/Sorting.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/Sorting.test.tsx
@@ -73,7 +73,7 @@ const DataGridWithSorting = () => {
 const DataGridWithManualSorting = () => {
   const pageSize = 8;
   const [data, setData] = useState<Payment[]>(originData.slice(0, pageSize));
-  const [sorting, setSorting] = useState<Order | undefined>(undefined);
+  const [sorting, setSorting] = useState<Order<Payment> | undefined>(undefined);
   const [ps, setPs] = useState(pageSize);
 
   const table = useDataGrid({

--- a/packages/design-systems/src/components/composite/Datagrid/types.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/types.ts
@@ -30,7 +30,7 @@ export interface DataGridInstance<
   pageSizeOptions?: number[];
   enableDensity?: boolean;
   enableSorting?: boolean;
-  onSortChange?: (sorting: Order | undefined) => void;
+  onSortChange?: (sorting: Order<TData> | undefined) => void;
 }
 
 export type UseDataGridProps<TData extends Record<string, unknown>> = {
@@ -61,7 +61,7 @@ export type UseDataGridProps<TData extends Record<string, unknown>> = {
   enableDensity?: boolean;
   exportOptions?: ExportState<TData>;
   enableSorting?: boolean;
-  onSortChange?: (sorting: Order | undefined) => void;
+  onSortChange?: (sorting: Order<TData> | undefined) => void;
 };
 
 export type MetaType =
@@ -80,7 +80,7 @@ export type Column<TData> = {
   meta?: ColumnMeta<TData, unknown>;
 };
 
-export type Order = {
-  field: string;
+export type Order<TData> = {
+  field: keyof TData;
   direction: "Asc" | "Desc";
 };

--- a/packages/design-systems/src/components/composite/Datagrid/utils/test/index.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/utils/test/index.ts
@@ -389,7 +389,7 @@ export const setFilterChange = (
 
 export const setSortChange = (
   data: Payment[],
-  sorting: Order | undefined,
+  sorting: Order<Payment> | undefined,
 ): Payment[] => {
   if (!sorting) return data;
   return [...data].sort((a, b) => {


### PR DESCRIPTION
# Background

<!-- Why is this change necessary, how it came to be? -->


# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
This pull request contains changes that primarily focus on refining the type definitions and improving the type safety in the DataGrid component. The most significant changes include modifying the `Order` type to include a generic parameter, and updating the `useState` and `setSortChange` functions to use the updated `Order` type. Additionally, the version of the `@tailor-platform/design-systems` package has been incremented.

Type refinement:

* [`packages/design-systems/src/components/composite/Datagrid/types.ts`](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917L33-R33): Modified the `Order` type to include a generic parameter, and updated the `onSortChange` method in both `DataGridInstance` and `UseDataGridProps` interfaces to use the updated `Order` type. [[1]](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917L33-R33) [[2]](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917L64-R64) [[3]](diffhunk://#diff-941d961c106632be8cee06d9e24ca67f13ba99f146bdee9eaa0fcbb782908917L83-R84)
* `apps/storybook/src/stories/datagrid/DataGridManualSortingStory.tsx`, `apps/storybook/src/stories/datagrid/utils.ts`, `packages/design-systems/src/components/composite/Datagrid/ColumnFeature/Sorting.test.tsx`, `packages/design-systems/src/components/composite/Datagrid/utils/test/index.ts`: Updated the `useState` and `setSortChange` functions to use the updated `Order` type. [[1]](diffhunk://#diff-6ce52da4ed0675c15163334eb144cc88b229e97d9f380f57fa05a57578e6b0c1L25-R25) [[2]](diffhunk://#diff-24ac253e2db33b789d62ac00120b726c85986a2f410660df1ec3ed8874d9d98cL279-R279) [[3]](diffhunk://#diff-47e70a9461813b71fe504ba37d9041045b75d99d6f52bd1d84d3b419f02e67f0L76-R76) [[4]](diffhunk://#diff-1cdb03cdbe39d33a9f80d668c49bbd8b4331d959cca63add3750f6491deaf4eaL392-R392)

Version increment:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): Incremented the version of the `@tailor-platform/design-systems` package.