### PR TITLE
fix(ds): GQL conversion for "not-equal" generates "ne"

### DIFF
--- a/apps/storybook/src/stories/datagrid/utils.ts
+++ b/apps/storybook/src/stories/datagrid/utils.ts
@@ -13,7 +13,7 @@ export const setFilterChange = (
     case typeof filter?.and !== "undefined":
       if (
         typeof filter?.status?.eq !== "undefined" ||
-        typeof filter?.status?.neq !== "undefined"
+        typeof filter?.status?.ne !== "undefined"
       ) {
         if (
           typeof filter?.and?.amount === "object" &&
@@ -35,7 +35,7 @@ export const setFilterChange = (
                   data.filter(
                     (row) =>
                       row.amount === Number(eqValue) &&
-                      row.status !== filter.status.neq,
+                      row.status !== filter.status.ne,
                   ),
                 );
               }
@@ -56,7 +56,7 @@ export const setFilterChange = (
                   data.filter(
                     (row) =>
                       row.amount > Number(gtValue) &&
-                      row.status !== filter.status.neq,
+                      row.status !== filter.status.ne,
                   ),
                 );
               }
@@ -77,7 +77,7 @@ export const setFilterChange = (
                   data.filter(
                     (row) =>
                       row.amount < Number(ltValue) &&
-                      row.status !== filter.status.neq,
+                      row.status !== filter.status.ne,
                   ),
                 );
               }
@@ -98,7 +98,7 @@ export const setFilterChange = (
                   data.filter(
                     (row) =>
                       row.amount >= Number(gteValue) &&
-                      row.status !== filter.status.neq,
+                      row.status !== filter.status.ne,
                   ),
                 );
               }
@@ -119,7 +119,7 @@ export const setFilterChange = (
                   data.filter(
                     (row) =>
                       row.amount <= Number(lteValue) &&
-                      row.status !== filter.status.neq,
+                      row.status !== filter.status.ne,
                   ),
                 );
               }
@@ -185,15 +185,15 @@ export const setFilterChange = (
               }
               break;
             }
-            case "neq" in filter.and.status: {
-              const neqValue = filter.and.status.neq;
+            case "ne" in filter.and.status: {
+              const neValue = filter.and.status.ne;
               switch (true) {
                 case typeof filter?.amount?.eq !== "undefined":
                   setData(
                     data.filter(
                       (row) =>
                         row.amount === Number(filter.amount.eq) &&
-                        row.status !== neqValue,
+                        row.status !== neValue,
                     ),
                   );
                   break;
@@ -202,7 +202,7 @@ export const setFilterChange = (
                     data.filter(
                       (row) =>
                         row.amount > Number(filter.amount.gt) &&
-                        row.status !== neqValue,
+                        row.status !== neValue,
                     ),
                   );
                   break;
@@ -211,7 +211,7 @@ export const setFilterChange = (
                     data.filter(
                       (row) =>
                         row.amount < Number(filter.amount.lt) &&
-                        row.status !== neqValue,
+                        row.status !== neValue,
                     ),
                   );
                   break;
@@ -220,7 +220,7 @@ export const setFilterChange = (
                     data.filter(
                       (row) =>
                         row.amount >= Number(filter.amount.gte) &&
-                        row.status !== neqValue,
+                        row.status !== neValue,
                     ),
                   );
                   break;
@@ -229,7 +229,7 @@ export const setFilterChange = (
                     data.filter(
                       (row) =>
                         row.amount <= Number(filter.amount.lte) &&
-                        row.status !== neqValue,
+                        row.status !== neValue,
                     ),
                   );
                   break;
@@ -243,8 +243,8 @@ export const setFilterChange = (
     case typeof filter?.status?.eq !== "undefined":
       setData(data.filter((row) => row.status === filter.status.eq));
       break;
-    case typeof filter?.status?.neq !== "undefined":
-      setData(data.filter((row) => row.status !== filter.status.neq));
+    case typeof filter?.status?.ne !== "undefined":
+      setData(data.filter((row) => row.status !== filter.status.ne));
       break;
     case typeof filter?.amount?.eq !== "undefined":
       setData(data.filter((row) => row.amount === Number(filter.amount.eq)));

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/filter.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/filter.ts
@@ -7,7 +7,7 @@ const GraphQLFilterOperator = {
   GREATER_THAN: "gt",
   LESS_THAN_OR_EQUAL: "lte",
   GREATER_THAN_OR_EQUAL: "gte",
-  NOT_EQUAL: "neq",
+  NOT_EQUAL: "ne",
   CONTAINS: "contains",
 } as const;
 

--- a/packages/design-systems/src/components/composite/Datagrid/utils/test/index.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/utils/test/index.ts
@@ -133,7 +133,7 @@ export const setFilterChange = (
     case typeof filter?.and !== "undefined":
       if (
         typeof filter?.status?.eq !== "undefined" ||
-        typeof filter?.status?.neq !== "undefined"
+        typeof filter?.status?.ne !== "undefined"
       ) {
         if (
           typeof filter?.and?.amount === "object" &&
@@ -155,7 +155,7 @@ export const setFilterChange = (
                   data.filter(
                     (row) =>
                       row.amount === Number(eqValue) &&
-                      row.status !== filter.status.neq,
+                      row.status !== filter.status.ne,
                   ),
                 );
               }
@@ -176,7 +176,7 @@ export const setFilterChange = (
                   data.filter(
                     (row) =>
                       row.amount > Number(gtValue) &&
-                      row.status !== filter.status.neq,
+                      row.status !== filter.status.ne,
                   ),
                 );
               }
@@ -197,7 +197,7 @@ export const setFilterChange = (
                   data.filter(
                     (row) =>
                       row.amount < Number(ltValue) &&
-                      row.status !== filter.status.neq,
+                      row.status !== filter.status.ne,
                   ),
                 );
               }
@@ -218,7 +218,7 @@ export const setFilterChange = (
                   data.filter(
                     (row) =>
                       row.amount >= Number(gteValue) &&
-                      row.status !== filter.status.neq,
+                      row.status !== filter.status.ne,
                   ),
                 );
               }
@@ -239,7 +239,7 @@ export const setFilterChange = (
                   data.filter(
                     (row) =>
                       row.amount <= Number(lteValue) &&
-                      row.status !== filter.status.neq,
+                      row.status !== filter.status.ne,
                   ),
                 );
               }
@@ -305,15 +305,15 @@ export const setFilterChange = (
               }
               break;
             }
-            case "neq" in filter.and.status: {
-              const neqValue = filter.and.status.neq;
+            case "ne" in filter.and.status: {
+              const neValue = filter.and.status.ne;
               switch (true) {
                 case typeof filter?.amount?.eq !== "undefined":
                   setData(
                     data.filter(
                       (row) =>
                         row.amount === Number(filter.amount.eq) &&
-                        row.status !== neqValue,
+                        row.status !== neValue,
                     ),
                   );
                   break;
@@ -322,7 +322,7 @@ export const setFilterChange = (
                     data.filter(
                       (row) =>
                         row.amount > Number(filter.amount.gt) &&
-                        row.status !== neqValue,
+                        row.status !== neValue,
                     ),
                   );
                   break;
@@ -331,7 +331,7 @@ export const setFilterChange = (
                     data.filter(
                       (row) =>
                         row.amount < Number(filter.amount.lt) &&
-                        row.status !== neqValue,
+                        row.status !== neValue,
                     ),
                   );
                   break;
@@ -340,7 +340,7 @@ export const setFilterChange = (
                     data.filter(
                       (row) =>
                         row.amount >= Number(filter.amount.gte) &&
-                        row.status !== neqValue,
+                        row.status !== neValue,
                     ),
                   );
                   break;
@@ -349,7 +349,7 @@ export const setFilterChange = (
                     data.filter(
                       (row) =>
                         row.amount <= Number(filter.amount.lte) &&
-                        row.status !== neqValue,
+                        row.status !== neValue,
                     ),
                   );
                   break;
@@ -363,8 +363,8 @@ export const setFilterChange = (
     case typeof filter?.status?.eq !== "undefined":
       setData(data.filter((row) => row.status === filter.status.eq));
       break;
-    case typeof filter?.status?.neq !== "undefined":
-      setData(data.filter((row) => row.status !== filter.status.neq));
+    case typeof filter?.status?.ne !== "undefined":
+      setData(data.filter((row) => row.status !== filter.status.ne));
       break;
     case typeof filter?.amount?.eq !== "undefined":
       setData(data.filter((row) => row.amount === Number(filter.amount.eq)));


### PR DESCRIPTION
# Background

https://tailor.atlassian.net/browse/FL-180

# Changes
- packages/design-systems/src/components/composite/Datagrid/SearchFilter/filter.ts
=> The value of getLocalizedFilterConditions is set by [onChangeCondition](https://github.com/tailor-platform/frontend-packages/blob/62e043eef43eb9fac98409d846d689b893d76e55/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx#L85).