### PR TITLE
fix(dev-cli): pass minitailor port to the console

### DIFF
--- a/.github/workflows/release_package_dev-cli.yml
+++ b/.github/workflows/release_package_dev-cli.yml
@@ -1,0 +1,29 @@
+name: release @tailor-platform/dev-cli
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - packages/dev-cli/package.json
+
+jobs:
+  check-existing-release:
+    uses: ./.github/workflows/check_existing_release.yml
+    with:
+      package_name: dev-cli
+  make-release-if-needed:
+    needs: check-existing-release
+    if: ${{ needs.check-existing-release.outputs.tag_exists == 'false' }}
+    uses: ./.github/workflows/make_github_release.yml
+    with:
+      package_name: dev-cli
+      tag: ${{ needs.check-existing-release.outputs.tag }}
+  publish-npm-package:
+    needs:
+      - check-existing-release
+      - make-release-if-needed
+    uses: ./.github/workflows/publish_npm_package.yml
+    secrets: inherit
+    with:
+      package_name: dev-cli

--- a/packages/dev-cli/package.json
+++ b/packages/dev-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tailor-platform/dev-cli",
   "description": "Tailor Platform CLI for frontend devs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "files": [

--- a/packages/dev-cli/src/builtin/templates/compose.ts
+++ b/packages/dev-cli/src/builtin/templates/compose.ts
@@ -43,6 +43,7 @@ services:
     environment:
       NEXT_PUBLIC_API_URL: http://mini.tailor.tech:18090
       NEXT_PUBLIC_APP_HOST: http://desktop.tailor.tech:3030
+      NEXT_PUBLIC_MINITAILOR_PORT: 8000
     ports:
       - 3030:3000
     profiles:


### PR DESCRIPTION
# Background

The `NEXT_PUBLIC_MINITAILOR_PORT` env var is used by the console when accessing the subgraphs (for the regular use case, FE => BFF => PF, the `NEXT_PUBLIC_API_URL` is used)

# Changes

- add missing env var
- add release GHA workflow