### PR TITLE
fix(ds): add recipes for select

### DIFF
--- a/apps/storybook/src/stories/composite/Select.stories.tsx
+++ b/apps/storybook/src/stories/composite/Select.stories.tsx
@@ -47,7 +47,7 @@ export const Default: Story = {
         >
           <Select.Label className={classes.label}>Framework</Select.Label>
           <Select.Control>
-            <Select.Trigger className={classes.trigger}>
+            <Select.Trigger className={classes.trigger} disabled={false}>
               <Select.ValueText placeholder="Select a Framework" />
               <Select.Indicator>
                 <ChevronsUpDownIcon />

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.30.7",
+  "version": "0.30.8",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/theme/slot-recipes/select.ts
+++ b/packages/design-systems/src/theme/slot-recipes/select.ts
@@ -96,6 +96,13 @@ export const select = defineSlotRecipe({
       "& :where(svg)": {
         color: "fg.subtle",
       },
+      _disabled: {
+        color: "fg.disabled",
+        cursor: "not-allowed",
+        _hover: {
+          background: "transparent",
+        },
+      },
     },
     valueText: {
       color: "fg.default",


### PR DESCRIPTION
# Background

Select box does not look disabled when it is disabled
<!-- Why is this change necessary, how it came to be? -->

# Changes

before
<img width="486" alt="スクリーンショット 2024-05-23 10 50 51" src="https://github.com/tailor-platform/frontend-packages/assets/40710120/16511f3a-22e0-4d39-a464-761c304c3dcb">
after
<img width="449" alt="スクリーンショット 2024-05-23 10 51 04" src="https://github.com/tailor-platform/frontend-packages/assets/40710120/ebfcb50a-0ed3-484e-962c-75d78eefd756">


This pull request primarily focuses on enhancements to the Select component and a version update in the design systems package. The key changes include enabling the Select trigger by default, updating the design systems package version, and adding styling for the disabled state in the Select component.

User Interface Enhancements:
* [`apps/storybook/src/stories/composite/Select.stories.tsx`](diffhunk://#diff-92569757f6f2ecc0fbd0fb780e78037744f2d29ccf7e04f161f6e8c715863fb1L50-R50): The `Select.Trigger` component is now enabled by default, which improves user interaction by allowing the trigger to be interacted with immediately.
* [`packages/design-systems/src/theme/slot-recipes/select.ts`](diffhunk://#diff-8c52c00b814fe989e6908bbeec55085400d7a9b5f7ee5d2195cff98138c708b0R99-R105): Added styling for the disabled state of the Select component. This improves the visual feedback to the user when the component is disabled.

Package Update:
* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the design systems package has been updated from 0.30.7 to 0.30.8. This increment signifies the addition of minor changes or patches in the package.
<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
