### PR TITLE
fix: change className in table recipe

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.30.8",
+  "version": "0.30.9",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/theme/slot-recipes/table.ts
+++ b/packages/design-systems/src/theme/slot-recipes/table.ts
@@ -1,8 +1,8 @@
 import { defineSlotRecipe } from "@pandacss/dev";
 
 export const table = defineSlotRecipe({
-  className: "checkbox",
-  description: "The styles for the Checkbox component",
+  className: "table",
+  description: "The styles for the Table component",
   slots: ["table", "thead", "tbody", "tfoot", "tr", "th", "td", "caption"],
   base: {
     table: {


### PR DESCRIPTION
# Background

className was declared as checkbox in the table recipe
<!-- Why is this change necessary, how it came to be? -->

# Changes

This pull request in the `packages/design-systems` primarily includes updates to the package version and modifications to the `table` slot recipe. The most important changes are:

Package Version Update:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the package has been updated from `0.30.8` to `0.30.9`.

Slot Recipe Modification:

* [`packages/design-systems/src/theme/slot-recipes/table.ts`](diffhunk://#diff-1e1bdb644df894b1267eb51962195746b3a9df15d05a9d5c3f611ccb3aca1a59L4-R5): The `className` and `description` fields in the `table` slot recipe have been updated from `checkbox` and "The styles for the Checkbox component" to `table` and "The styles for the Table component" respectively.
<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
