### PR TITLE
fix(auth): saml callback

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.2",
+  "version": "0.7.2-preview.1",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.2-preview.1",
+  "version": "0.7.3",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/src/core/strategies/saml.test.ts
+++ b/packages/auth/src/core/strategies/saml.test.ts
@@ -13,7 +13,7 @@ describe("saml strategy", () => {
     const payload = strategy.authenticate(config, { redirectPath: "/" });
     expect(payload.mode).toBe("redirection");
     expect(payload.uri).toBe(
-      "http://yourapp.mini.tailor.tech:8000/auth/login?redirect_uri=http://localhost:3000/__auth/callback/saml?redirect_uri=/&state=/",
+      "http://yourapp.mini.tailor.tech:8000/auth/login?redirect_uri=http://localhost:3000/__auth/callback/saml&state=/",
     );
   });
   it("saml callback parameter error", async () => {

--- a/packages/auth/src/core/strategies/saml.ts
+++ b/packages/auth/src/core/strategies/saml.ts
@@ -16,9 +16,7 @@ export class SAMLStrategy implements AbstractStrategy<Options> {
   authenticate(config: Config, options: Options) {
     const apiLoginUrl = config.apiUrl(config.loginPath());
     const callbackPath = callbackByStrategy(this.name());
-    const redirectUrl = encodeURI(
-      `${config.appUrl(callbackPath)}?redirect_uri=${options.redirectPath ?? "/"}`,
-    );
+    const redirectUrl = encodeURI(config.appUrl(callbackPath));
     const relayState = encodeURI(options.redirectPath ?? "/");
     return {
       mode: "redirection" as const,

--- a/packages/auth/src/core/strategies/strategy.test.ts
+++ b/packages/auth/src/core/strategies/strategy.test.ts
@@ -7,16 +7,17 @@ import { AbstractStrategy } from "@core";
 
 describe("redirection", () => {
   const buildMockedRedirectionURL = (strategy: string) =>
-    `https://mock-api-url.com/mock-login?redirect_uri=http://localhost:3000/__auth/callback/${strategy}?redirect_uri=/redirect-path`;
+    `https://mock-api-url.com/mock-login?redirect_uri=http://localhost:3000/__auth/callback/${strategy}`;
 
   const cases = {
     default: {
       builder: () => defaultStrategy,
-      uri: buildMockedRedirectionURL("default"),
+      uri:
+        buildMockedRedirectionURL("default") + "?redirect_uri=/redirect-path",
     },
     oidc: {
       builder: () => new OIDCStrategy(),
-      uri: buildMockedRedirectionURL("oidc"),
+      uri: buildMockedRedirectionURL("oidc") + "?redirect_uri=/redirect-path",
     },
     saml: {
       builder: () => new SAMLStrategy(),


### PR DESCRIPTION
# Background

fix saml callback url.
there is no need to redirect_url

This pull request primarily focuses on the `packages/auth` package, including a version bump and a modification to the `SAMLStrategy` class.

Version Changes:
* [`packages/auth/package.json`](diffhunk://#diff-79fbe1d958aec3ec2b3d46cdc5b9b34cd834f48550895ce9484f10c0f77a4a8fL3-R3): The version of `@tailor-platform/auth` has been updated from `0.7.2` to `0.7.3`.

Codebase simplification:
* [`packages/auth/src/core/strategies/saml.ts`](diffhunk://#diff-b8d36342ffe446a273c9df5032f5ccf6e95d6b48f7af6629ac54e309eb374c14L19-R19): In the `authenticate` method of the `SAMLStrategy` class, the `redirectUrl` has been simplified to no longer include the `redirect_uri` query parameter. The `relayState` variable is now responsible for encoding the `redirectPath`.
