### PR TITLE
fix(auth): remove tokens on 401

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.3",
+  "version": "0.7.4-preview.0",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.4-preview.0",
+  "version": "0.7.4",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/src/adapters/apollo/link.ts
+++ b/packages/auth/src/adapters/apollo/link.ts
@@ -1,6 +1,7 @@
 import { from, HttpLink, makeVar, ServerError } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
 import { onError } from "@apollo/client/link/error";
+import { logoutInternal } from "@client/hooks";
 import { Config } from "@core/config";
 import { internalClientSessionPath } from "@core/path";
 import { SessionResult } from "@core/types";
@@ -70,7 +71,7 @@ export const authenticatedHttpLink = (config: Config) =>
       if (networkError?.name === "ServerError") {
         const serverErrorStatusCode = (networkError as ServerError).statusCode;
         if (serverErrorStatusCode === 401) {
-          location.replace(config.unauthorizedPath());
+          logoutInternal(config, config.unauthorizedPath());
         }
       }
     }),

--- a/packages/auth/src/client/hooks.ts
+++ b/packages/auth/src/client/hooks.ts
@@ -6,6 +6,7 @@ import {
   internalLogoutPath,
   internalUnauthorizedPath,
 } from "@core/path";
+import { Config } from "@core";
 
 const NoWindowError = new Error(
   "window object should be available to use this function",
@@ -126,13 +127,7 @@ export const useAuth = () => {
      */
     logout: (params?: LogoutParams) => {
       assertWindowIsAvailable();
-
-      const searchParams = new URLSearchParams({
-        redirect_path: params?.redirectPath || config.loginPath(),
-      });
-      window.location.replace(
-        `${config.appUrl(internalLogoutPath)}?${searchParams.toString()}`,
-      );
+      logoutInternal(config, params?.redirectPath);
     },
     refreshToken,
   };
@@ -192,4 +187,18 @@ export const useSession = (options?: SessionOption) => {
   }
 
   return { token: session.token };
+};
+
+/**
+ * Internal commonized procedure to logout the current user.
+ *
+ * @internal
+ */
+export const logoutInternal = (config: Config, redirectPath?: string) => {
+  const searchParams = new URLSearchParams({
+    redirect_path: redirectPath || config.loginPath(),
+  });
+  window.location.replace(
+    `${config.appUrl(internalLogoutPath)}?${searchParams.toString()}`,
+  );
 };


### PR DESCRIPTION
# Background

In PS apps, we have been observing that token expiration causes the infinite loop. 

# Changes

Update the custom ApolloLink to delete the expired token when it gets 401 from Tailor Platform backend.