### PR TITLE
fix(ds): fix localization in filter

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.30.9",
+  "version": "0.30.10",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
@@ -223,18 +223,18 @@ describe(
       await user.click(selectConditionButton);
 
       const equalConditionOption = within(selectConditionOptions).getByText(
-        "に等しい",
+        "等しい",
       );
       expect(equalConditionOption).toBeVisible();
       expect(
-        within(selectConditionOptions).getByText("に等しくない"),
+        within(selectConditionOptions).getByText("等しくない"),
       ).toBeVisible();
-      expect(within(selectConditionOptions).queryByText("を含む")).toBeNull();
+      expect(within(selectConditionOptions).queryByText("含む")).toBeNull();
 
       await user.click(equalConditionOption);
 
       expect(equalConditionOption).not.toBeVisible();
-      expect(selectCondition).toHaveTextContent("に等しい");
+      expect(selectCondition).toHaveTextContent("等しい");
 
       //Select value
       const selectValue = screen.getByTestId("select-input-value");
@@ -304,18 +304,18 @@ describe(
       await user.click(selectConditionButton);
 
       const equalConditionOption = within(selectConditionOptions).getByText(
-        "に等しい",
+        "等しい",
       );
       expect(equalConditionOption).toBeVisible();
-      expect(within(selectConditionOptions).getByText("を含む")).toBeVisible();
+      expect(within(selectConditionOptions).getByText("含む")).toBeVisible();
       expect(
-        within(selectConditionOptions).queryByText("に等しくない"),
+        within(selectConditionOptions).queryByText("等しくない"),
       ).toBeNull();
 
       await user.click(equalConditionOption);
 
       expect(equalConditionOption).not.toBeVisible();
-      expect(selectCondition).toHaveTextContent("に等しい");
+      expect(selectCondition).toHaveTextContent("等しい");
 
       // Input value
       const inputValue = screen.getByTestId("select-input-value");
@@ -369,7 +369,7 @@ describe(
       await user.click(selectConditionButton);
 
       const equalConditionOption = within(selectConditionOptions).getByText(
-        "に等しい",
+        "等しい",
       );
       expect(equalConditionOption).toBeVisible();
       expect(
@@ -381,12 +381,12 @@ describe(
       expect(within(selectConditionOptions).getByText("以上")).toBeVisible();
       expect(within(selectConditionOptions).getByText("以下")).toBeVisible();
 
-      expect(within(selectConditionOptions).queryByText("を含む")).toBeNull();
+      expect(within(selectConditionOptions).queryByText("含む")).toBeNull();
 
       await user.click(equalConditionOption);
 
       expect(equalConditionOption).not.toBeVisible();
-      expect(selectCondition).toHaveTextContent("に等しい");
+      expect(selectCondition).toHaveTextContent("等しい");
 
       // Input value
       const inputValue = await screen.findByTestId("select-input-value");
@@ -439,9 +439,7 @@ describe(
         "以下",
       );
       expect(lteConditionOption).toBeVisible();
-      expect(
-        within(selectConditionOptions).getByText("に等しい"),
-      ).toBeVisible();
+      expect(within(selectConditionOptions).getByText("等しい")).toBeVisible();
       expect(
         within(selectConditionOptions).getByText("より大きい"),
       ).toBeVisible();
@@ -450,7 +448,7 @@ describe(
       ).toBeVisible();
       expect(within(selectConditionOptions).getByText("以上")).toBeVisible();
 
-      expect(within(selectConditionOptions).queryByText("を含む")).toBeNull();
+      expect(within(selectConditionOptions).queryByText("含む")).toBeNull();
 
       await user.click(lteConditionOption);
 
@@ -512,25 +510,25 @@ describe(
       await user.click(selectConditionButton);
 
       const eqConditionOption = within(selectConditionOptions).getByText(
-        "に等しい",
+        "等しい",
       );
       expect(eqConditionOption).toBeVisible();
 
       expect(
-        within(selectConditionOptions).getByText("に等しくない"),
+        within(selectConditionOptions).getByText("等しくない"),
       ).toBeVisible();
-      expect(screen.queryByText("を含む")).toBeNull();
+      expect(screen.queryByText("含む")).toBeNull();
       expect(screen.queryByText("より大きい")).toBeNull();
       expect(screen.queryByText("より小さい")).toBeNull();
       expect(screen.queryByText("以上")).toBeNull();
       expect(screen.queryByText("以下")).toBeNull();
 
-      expect(screen.queryByText("を含む")).toBeNull();
+      expect(screen.queryByText("含む")).toBeNull();
 
       await user.click(eqConditionOption);
 
       expect(eqConditionOption).not.toBeVisible();
-      expect(selectCondition).toHaveTextContent("に等しい");
+      expect(selectCondition).toHaveTextContent("等しい");
 
       //Select value
       const selectValue = screen.getByTestId("select-input-value");
@@ -567,7 +565,7 @@ describe(
       //Select column
       await selectColumn(screen, user, 0, "Status");
       //Select condition
-      await selectCondition(screen, user, 0, "に等しい");
+      await selectCondition(screen, user, 0, "等しい");
       //Select value
       await selectValue(screen, user, 0, "pending");
 
@@ -611,7 +609,7 @@ describe(
       //Select column
       await selectColumn(screen, user, 1, "Status");
       //Select condition
-      await selectCondition(screen, user, 1, "に等しい");
+      await selectCondition(screen, user, 1, "等しい");
       //Select value
       await selectValue(screen, user, 1, "pending");
 
@@ -684,9 +682,7 @@ describe(
         "以下",
       );
       expect(lteConditionOption).toBeVisible();
-      expect(
-        within(selectConditionOptions).getByText("に等しい"),
-      ).toBeVisible();
+      expect(within(selectConditionOptions).getByText("等しい")).toBeVisible();
       expect(
         within(selectConditionOptions).getByText("より大きい"),
       ).toBeVisible();
@@ -695,7 +691,7 @@ describe(
       ).toBeVisible();
       expect(within(selectConditionOptions).getByText("以上")).toBeVisible();
 
-      expect(within(selectConditionOptions).queryByText("を含む")).toBeNull();
+      expect(within(selectConditionOptions).queryByText("含む")).toBeNull();
 
       await user.click(lteConditionOption);
 

--- a/packages/design-systems/src/locales/ja.ts
+++ b/packages/design-systems/src/locales/ja.ts
@@ -30,9 +30,9 @@ export const LOCALIZATION_JA: Localization = {
       conditionLabel: "条件",
       conditionPlaceholder: "条件を選択",
       operatorLabel: {
-        equal: "に等しい",
-        notEqual: "に等しくない",
-        include: "を含む",
+        equal: "等しい",
+        notEqual: "等しくない",
+        include: "含む",
         notInclude: "含まない",
         greaterThan: "より大きい",
         lessThan: "より小さい",


### PR DESCRIPTION
# Background

Regarding the wording of the custom filter, the structure felt strange due to the direct translation from English to Japanese

# Changes

This pull request primarily involves two types of changes: a version update in the `package.json` file for the `@tailor-platform/design-systems` package, and modifications to the localization and test files for the `CustomFilter` component in the `Datagrid` of the `design-systems` package. The modifications in the test files are due to changes in the Japanese localization strings.

Here are the most important changes:

Version Update:
* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the `@tailor-platform/design-systems` package has been updated from `0.30.9` to `0.30.10`.

Localization and Test Changes:
* [`packages/design-systems/src/locales/ja.ts`](diffhunk://#diff-9471627b37051b709de5d94829c2b7a5a7f93beff388d175f45f53cd71df861bL33-R35): The Japanese localization strings for the `equal`, `notEqual`, and `include` conditions have been simplified.
* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx`](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL226-R237): Multiple instances of test cases have been updated to reflect the changes in the Japanese localization strings. [[1]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL226-R237) [[2]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL307-R318) [[3]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL372-R372) [[4]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL384-R389) [[5]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL442-R442) [[6]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL453-R451) [[7]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL515-R531) [[8]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL570-R568) [[9]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL614-R612) [[10]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL687-R685) [[11]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL698-R694)