### PR TITLE
fix(ds): remove Portal

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.30.9",
+  "version": "0.30.11",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { CollectionItem } from "@ark-ui/react/select";
-import { Portal } from "@ark-ui/react/portal";
 import { type PaginationState } from "@tanstack/react-table";
 import { select } from "@tailor-platform/styled-system/recipes";
 import { HStack } from "@tailor-platform/styled-system/jsx";
@@ -68,32 +67,30 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
               <ChevronDown />
             </Select.Trigger>
           </Select.Control>
-          <Portal>
-            <Select.Positioner className={classes.positioner}>
-              <Select.Content className={classes.content}>
-                <Select.ItemGroup
-                  className={classes.itemGroup}
-                  id="jointConditions"
-                  data-testid="select-page-size-options"
-                >
-                  {pageSizeOptions.map((item) => (
-                    <Select.Item
-                      className={classes.item}
-                      key={"pageSize" + item}
-                      item={item}
-                    >
-                      <Select.ItemText className={classes.itemText}>
-                        {item}
-                      </Select.ItemText>
-                      <Select.ItemIndicator className={classes.itemIndicator}>
-                        <CheckIcon />
-                      </Select.ItemIndicator>
-                    </Select.Item>
-                  ))}
-                </Select.ItemGroup>
-              </Select.Content>
-            </Select.Positioner>
-          </Portal>
+          <Select.Positioner className={classes.positioner}>
+            <Select.Content className={classes.content}>
+              <Select.ItemGroup
+                className={classes.itemGroup}
+                id="jointConditions"
+                data-testid="select-page-size-options"
+              >
+                {pageSizeOptions.map((item) => (
+                  <Select.Item
+                    className={classes.item}
+                    key={"pageSize" + item}
+                    item={item}
+                  >
+                    <Select.ItemText className={classes.itemText}>
+                      {item}
+                    </Select.ItemText>
+                    <Select.ItemIndicator className={classes.itemIndicator}>
+                      <CheckIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                ))}
+              </Select.ItemGroup>
+            </Select.Content>
+          </Select.Positioner>
         </Select.Root>
       </HStack>
       <HStack gap={2}>

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import { CollectionItem } from "@ark-ui/react/select";
-import { Portal } from "@ark-ui/react/portal";
 import { select } from "@tailor-platform/styled-system/recipes";
 import { HStack } from "@tailor-platform/styled-system/jsx";
 import {
@@ -62,32 +61,30 @@ export const Pagination = <TData extends Record<string, unknown>>({
               <ChevronDown />
             </Select.Trigger>
           </Select.Control>
-          <Portal>
-            <Select.Positioner className={classes.positioner}>
-              <Select.Content className={classes.content}>
-                <Select.ItemGroup
-                  className={classes.itemGroup}
-                  id="jointConditions"
-                  data-testid="select-page-size-options"
-                >
-                  {pageSizeOptions.map((item) => (
-                    <Select.Item
-                      className={classes.item}
-                      key={"pageSize" + item}
-                      item={item}
-                    >
-                      <Select.ItemText className={classes.itemText}>
-                        {item}
-                      </Select.ItemText>
-                      <Select.ItemIndicator className={classes.itemIndicator}>
-                        <CheckIcon />
-                      </Select.ItemIndicator>
-                    </Select.Item>
-                  ))}
-                </Select.ItemGroup>
-              </Select.Content>
-            </Select.Positioner>
-          </Portal>
+          <Select.Positioner className={classes.positioner}>
+            <Select.Content className={classes.content}>
+              <Select.ItemGroup
+                className={classes.itemGroup}
+                id="jointConditions"
+                data-testid="select-page-size-options"
+              >
+                {pageSizeOptions.map((item) => (
+                  <Select.Item
+                    className={classes.item}
+                    key={"pageSize" + item}
+                    item={item}
+                  >
+                    <Select.ItemText className={classes.itemText}>
+                      {item}
+                    </Select.ItemText>
+                    <Select.ItemIndicator className={classes.itemIndicator}>
+                      <CheckIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                ))}
+              </Select.ItemGroup>
+            </Select.Content>
+          </Select.Positioner>
         </Select.Root>
       </HStack>
       <HStack gap={2}>


### PR DESCRIPTION
# Background

To perform pagination on a modal, the modal closes.

# Changes

This pull request primarily focuses on the `@tailor-platform/design-systems` package. The changes include an update to the package version and modifications to the `ManualPagination.tsx` and `Pagination.tsx` components in the `Datagrid` directory. The `Portal` component from `@ark-ui/react/portal` has been removed from these two components.

Here are the key changes:

Package version update:
* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The package version has been updated from `0.30.9` to `0.30.11`.

Changes in `ManualPagination.tsx`:
* The `Portal` import statement has been removed.
* The `Portal` component wrapping the `Select.Positioner` has been removed. [[1]](diffhunk://#diff-b18e0964543b2ec2d14856c16e5fdcd91ac494a6516b1f6bacd68b4a039cf154L71) [[2]](diffhunk://#diff-b18e0964543b2ec2d14856c16e5fdcd91ac494a6516b1f6bacd68b4a039cf154L96)

Changes in `Pagination.tsx`:
* The `Portal` import statement has been removed.
* The `Portal` component wrapping the `Select.Positioner` has been removed. [[1]](diffhunk://#diff-cf4ddce20ee1ffa24bf1bad804161e44abdbe499f279fe6bfba9ba369a9b9bcbL65) [[2]](diffhunk://#diff-cf4ddce20ee1ffa24bf1bad804161e44abdbe499f279fe6bfba9ba369a9b9bcbL90)

These changes seem to be part of a refactoring effort to simplify the codebase by removing the unnecessary `Portal` component.