### PR TITLE
fix(ds): localize in filter

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.30.11",
+  "version": "0.30.12",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
@@ -535,14 +535,14 @@ describe(
       const selectValueButton = within(selectValue).getByRole("button");
       await user.click(selectValueButton);
 
-      const trueOption = screen.getByRole("option", { name: "true" });
+      const trueOption = screen.getByRole("option", { name: "はい" });
       expect(trueOption).toBeVisible();
-      expect(screen.getByRole("option", { name: "false" })).toBeVisible();
+      expect(screen.getByRole("option", { name: "いいえ" })).toBeVisible();
 
       await user.click(trueOption);
 
       expect(trueOption).not.toBeVisible();
-      expect(selectValue).toHaveTextContent("true");
+      expect(selectValue).toHaveTextContent("はい");
 
       //Check filters
       await waitFor(() => {

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
@@ -397,7 +397,10 @@ export const FilterRow = <TData extends Record<string, unknown>>(
         ) : selectedColumnObject?.meta?.type === "boolean" ? (
           <Select.Root
             className={classes.root}
-            items={["true", "false"]}
+            items={[
+              localization.filter.columnBoolean.true,
+              localization.filter.columnBoolean.false,
+            ]}
             positioning={{ sameWidth: true }}
             closeOnSelect
             width={180}
@@ -426,10 +429,10 @@ export const FilterRow = <TData extends Record<string, unknown>>(
                   <Select.Item
                     className={classes.item}
                     key={"selectInput" + 0}
-                    item={"true"}
+                    item={localization.filter.columnBoolean.true}
                   >
                     <Select.ItemText className={classes.itemText}>
-                      {"true"}
+                      {localization.filter.columnBoolean.true}
                     </Select.ItemText>
                     <Select.ItemIndicator className={classes.itemIndicator}>
                       <CheckIcon />
@@ -438,10 +441,10 @@ export const FilterRow = <TData extends Record<string, unknown>>(
                   <Select.Item
                     className={classes.item}
                     key={"selectInput" + 1}
-                    item={"false"}
+                    item={localization.filter.columnBoolean.false}
                   >
                     <Select.ItemText className={classes.itemText}>
-                      {"false"}
+                      {localization.filter.columnBoolean.false}
                     </Select.ItemText>
                     <Select.ItemIndicator className={classes.itemIndicator}>
                       <CheckIcon />

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { LOCALIZATION_JA } from "../../../../locales/ja";
+import { LOCALIZATION_EN } from "../../../../locales/en";
 import { Payment, columns } from "../utils/test";
 import { FilterRowData, useCustomFilter } from "./useCustomFilter";
 import { jointConditions } from "./filter";
@@ -310,6 +311,7 @@ describe("useCustomFilter", () => {
         filter,
         graphQLQueryObject,
         "number",
+        LOCALIZATION_EN,
       );
     });
 
@@ -347,6 +349,7 @@ describe("useCustomFilter", () => {
         filter,
         graphQLQueryObject,
         "number",
+        LOCALIZATION_EN,
       );
     });
 
@@ -390,6 +393,7 @@ describe("useCustomFilter", () => {
         filter,
         graphQLQueryObject,
         "number",
+        LOCALIZATION_EN,
       );
     });
 
@@ -549,31 +553,37 @@ describe("useCustomFilter", () => {
         filter,
         graphQLQueryObject,
         "boolean",
+        LOCALIZATION_EN,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter,
         graphQLQueryObject,
         "boolean",
+        LOCALIZATION_EN,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter2,
         graphQLQueryObject,
         "string",
+        LOCALIZATION_EN,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter3,
         graphQLQueryObject,
         "string",
+        LOCALIZATION_EN,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter4,
         graphQLQueryObject,
         "string",
+        LOCALIZATION_EN,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter5,
         graphQLQueryObject,
         "number",
+        LOCALIZATION_EN,
       );
     });
 
@@ -658,31 +668,37 @@ describe("useCustomFilter", () => {
         filter,
         graphQLQueryObject,
         "boolean",
+        LOCALIZATION_EN,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter,
         graphQLQueryObject,
         "boolean",
+        LOCALIZATION_EN,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter2,
         graphQLQueryObject,
         "string",
+        LOCALIZATION_EN,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter3,
         graphQLQueryObject,
         "string",
+        LOCALIZATION_EN,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter4,
         graphQLQueryObject,
         "string",
+        LOCALIZATION_EN,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter5,
         graphQLQueryObject,
         "number",
+        LOCALIZATION_EN,
       );
     });
 

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.test.tsx
@@ -1,7 +1,6 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { LOCALIZATION_JA } from "../../../../locales/ja";
-import { LOCALIZATION_EN } from "../../../../locales/en";
 import { Payment, columns } from "../utils/test";
 import { FilterRowData, useCustomFilter } from "./useCustomFilter";
 import { jointConditions } from "./filter";
@@ -311,7 +310,7 @@ describe("useCustomFilter", () => {
         filter,
         graphQLQueryObject,
         "number",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
     });
 
@@ -349,7 +348,7 @@ describe("useCustomFilter", () => {
         filter,
         graphQLQueryObject,
         "number",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
     });
 
@@ -393,7 +392,7 @@ describe("useCustomFilter", () => {
         filter,
         graphQLQueryObject,
         "number",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
     });
 
@@ -553,37 +552,37 @@ describe("useCustomFilter", () => {
         filter,
         graphQLQueryObject,
         "boolean",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter,
         graphQLQueryObject,
         "boolean",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter2,
         graphQLQueryObject,
         "string",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter3,
         graphQLQueryObject,
         "string",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter4,
         graphQLQueryObject,
         "string",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter5,
         graphQLQueryObject,
         "number",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
     });
 
@@ -668,37 +667,37 @@ describe("useCustomFilter", () => {
         filter,
         graphQLQueryObject,
         "boolean",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter,
         graphQLQueryObject,
         "boolean",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter2,
         graphQLQueryObject,
         "string",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter3,
         graphQLQueryObject,
         "string",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter4,
         graphQLQueryObject,
         "string",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
       result.current.addToGraphQLQueryFilterRecursively(
         filter5,
         graphQLQueryObject,
         "number",
-        LOCALIZATION_EN,
+        LOCALIZATION_JA,
       );
     });
 

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts
@@ -378,6 +378,7 @@ export const useCustomFilter = <TData>({
       filter: FilterRowState,
       graphQLQueryObject: GraphQLQueryFilter,
       metaType: MetaType | undefined,
+      localization: Localization,
     ) => {
       const { column, condition, value, jointCondition } = filter;
 
@@ -412,7 +413,7 @@ export const useCustomFilter = <TData>({
           case "boolean":
             graphQLQueryObject[key] = generateGraphQLQueryObject(
               isExitJointCondition,
-              value.toLowerCase() === "true",
+              value.toLowerCase() === localization.filter.columnBoolean.true,
             );
             break;
           case "dateTime": {
@@ -449,6 +450,7 @@ export const useCustomFilter = <TData>({
             filter,
             graphQLQueryObject[jointCondition] as GraphQLQueryFilter,
             metaType,
+            localization,
           );
         } else {
           assignValueToQueryObject(jointCondition, true);
@@ -480,6 +482,7 @@ export const useCustomFilter = <TData>({
             row.currentState,
             newFilterRowsState,
             metaType,
+            localization,
           );
         }
       }

--- a/packages/design-systems/src/locales/en.ts
+++ b/packages/design-systems/src/locales/en.ts
@@ -40,6 +40,10 @@ export const LOCALIZATION_EN: Localization = {
         lessThanOrEqual: "Less Than Or Equal",
       },
     },
+    columnBoolean: {
+      true: "true",
+      false: "false",
+    },
     valueLabel: "Value",
     valuePlaceholder: "Input Value",
     valuePlaceholderEnum: "Select Value",

--- a/packages/design-systems/src/locales/ja.ts
+++ b/packages/design-systems/src/locales/ja.ts
@@ -40,6 +40,10 @@ export const LOCALIZATION_JA: Localization = {
         lessThanOrEqual: "以下",
       },
     },
+    columnBoolean: {
+      true: "はい",
+      false: "いいえ",
+    },
     valueLabel: "値",
     valuePlaceholder: "値を入力",
     valuePlaceholderEnum: "値を選択",

--- a/packages/design-systems/src/locales/types.ts
+++ b/packages/design-systems/src/locales/types.ts
@@ -26,6 +26,10 @@ export interface Localization {
         lessThanOrEqual: string;
       };
     };
+    columnBoolean: {
+      true: string;
+      false: string;
+    };
     valueLabel: string;
     valuePlaceholder: string;
     valuePlaceholderEnum: string;


### PR DESCRIPTION
# Background

When locale is set to Japanese, boolean options are displayed as "true" and "false".

# Changes

This pull request primarily focuses on the localization of boolean values in the `Datagrid` component and its associated tests. The changes involve replacing hardcoded boolean strings with localized versions and passing the localization object to various functions. The localization object has been extended to include localized boolean values.

Localization changes:

* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx`](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL400-R403): Replaced hardcoded boolean strings with localized versions in `FilterRow` component. [[1]](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL400-R403) [[2]](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL429-R435) [[3]](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL441-R447)
* `packages/design-systems/src/locales/en.ts`, `packages/design-systems/src/locales/ja.ts`: Added localized boolean values to English and Japanese localization objects. [[1]](diffhunk://#diff-1858a96bd5462cc084b42e493806c658aaba5221402dea60464595a3ad912410R43-R46) [[2]](diffhunk://#diff-9471627b37051b709de5d94829c2b7a5a7f93beff388d175f45f53cd71df861bR43-R46)
* [`packages/design-systems/src/locales/types.ts`](diffhunk://#diff-23d05766725ea33f62dee80b9e86ba60c162dea3dba29691754d18caad56b073R29-R32): Extended the `Localization` interface to include localized boolean values.

Changes in tests:

* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.test.tsx`](diffhunk://#diff-23497eaff0d7e8e80a622b3ec3d53b7fe5532eab7c5170919360aef0fcf22d7dR4): Imported English localization and passed it to various functions in tests. [[1]](diffhunk://#diff-23497eaff0d7e8e80a622b3ec3d53b7fe5532eab7c5170919360aef0fcf22d7dR4) [[2]](diffhunk://#diff-23497eaff0d7e8e80a622b3ec3d53b7fe5532eab7c5170919360aef0fcf22d7dR314) [[3]](diffhunk://#diff-23497eaff0d7e8e80a622b3ec3d53b7fe5532eab7c5170919360aef0fcf22d7dR352) [[4]](diffhunk://#diff-23497eaff0d7e8e80a622b3ec3d53b7fe5532eab7c5170919360aef0fcf22d7dR396) [[5]](diffhunk://#diff-23497eaff0d7e8e80a622b3ec3d53b7fe5532eab7c5170919360aef0fcf22d7dR556-R586) [[6]](diffhunk://#diff-23497eaff0d7e8e80a622b3ec3d53b7fe5532eab7c5170919360aef0fcf22d7dR671-R701)

Changes in `useCustomFilter`:

* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts`](diffhunk://#diff-35b3c6fcdd195e366afc62165424a019f1d0061113720eb4b1cabef7ccb92f22R381): Passed localization to various functions and used localized boolean values in `useCustomFilter`. [[1]](diffhunk://#diff-35b3c6fcdd195e366afc62165424a019f1d0061113720eb4b1cabef7ccb92f22R381) [[2]](diffhunk://#diff-35b3c6fcdd195e366afc62165424a019f1d0061113720eb4b1cabef7ccb92f22L415-R416) [[3]](diffhunk://#diff-35b3c6fcdd195e366afc62165424a019f1d0061113720eb4b1cabef7ccb92f22R453) [[4]](diffhunk://#diff-35b3c6fcdd195e366afc62165424a019f1d0061113720eb4b1cabef7ccb92f22R485)