### PR TITLE
fix(auth): fix IDP initiated SAML flow and improved error handling

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.5-preview.1",
+  "version": "0.7.5-preview.2",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.5-preview.4",
+  "version": "0.7.5-preview.5",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.5-preview.2",
+  "version": "0.7.5-preview.3",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.5-preview.5",
+  "version": "0.7.5-preview.6",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.4",
+  "version": "0.7.5-preview.0",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.5-preview.3",
+  "version": "0.7.5-preview.4",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.5-preview.0",
+  "version": "0.7.5-preview.1",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/auth",
-  "version": "0.7.5-preview.6",
+  "version": "0.7.5",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -1,0 +1,1 @@
+export const NoSessionError = new Error("No session available");

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -1,7 +1,7 @@
 class AuthError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = this.constructor.name;
+    this.name = "AuthError";
   }
 }
 

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -1,1 +1,8 @@
-export const NoSessionError = new Error("No session available");
+class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+export const NoSessionError = new AuthError("No session available");

--- a/packages/auth/src/core/errors.ts
+++ b/packages/auth/src/core/errors.ts
@@ -5,4 +5,8 @@ class AuthError extends Error {
   }
 }
 
-export const NoSessionError = new AuthError("No session available");
+// An error that is thrown when the token is unavailable or empty because `tailor.token` is not set
+export const TokenUnavailableError = new AuthError("Token is unavailable");
+
+// An error that is thrown from client hooks in case the session is invalid
+export const InvalidSessionError = new AuthError("Invalid session");

--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -5,6 +5,6 @@ export type {
   SessionResult,
   UserInfo,
 } from "@core/types";
-export { NoSessionError } from "@core/errors";
+export { TokenUnavailableError, InvalidSessionError } from "@core/errors";
 export { Config } from "@core/config";
 export type { AbstractStrategy } from "@core/strategies/abstract";

--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -4,6 +4,7 @@ export type {
   SessionOption,
   SessionResult,
   UserInfo,
+  NoSessionError,
 } from "@core/types";
 export { Config } from "@core/config";
 export type { AbstractStrategy } from "@core/strategies/abstract";

--- a/packages/auth/src/core/index.ts
+++ b/packages/auth/src/core/index.ts
@@ -4,7 +4,7 @@ export type {
   SessionOption,
   SessionResult,
   UserInfo,
-  NoSessionError,
 } from "@core/types";
+export { NoSessionError } from "@core/errors";
 export { Config } from "@core/config";
 export type { AbstractStrategy } from "@core/strategies/abstract";

--- a/packages/auth/src/core/loader.ts
+++ b/packages/auth/src/core/loader.ts
@@ -1,6 +1,6 @@
 import { internalClientSessionPath } from "@core/path";
 import { Config } from "@core/config";
-import { SessionResult, UserInfo } from "@core/types";
+import { NoSessionError, SessionResult, UserInfo } from "@core/types";
 
 // SuspenseLoader is a class that abstracts out the logic of loading a resource from a remote server,
 // and caches the result for React Suspense support in client components.
@@ -55,7 +55,7 @@ export const internalUserinfoLoader = new SuspenseLoader<UserInfo>(
     const resp = await fetchSession(config);
     const session = (await resp.json()) as unknown as SessionResult;
     if (session.token === "" || session.token === null) {
-      throw new Error("No session token available");
+      throw NoSessionError;
     }
 
     return await fetch(config.apiUrl(config.userInfoPath()), {

--- a/packages/auth/src/core/loader.ts
+++ b/packages/auth/src/core/loader.ts
@@ -1,7 +1,7 @@
 import { internalClientSessionPath } from "@core/path";
 import { Config } from "@core/config";
 import { SessionResult, UserInfo } from "@core/types";
-import { NoSessionError } from "@core/errors";
+import { TokenUnavailableError, InvalidSessionError } from "@core/errors";
 
 // SuspenseLoader is a class that abstracts out the logic of loading a resource from a remote server,
 // and caches the result for React Suspense support in client components.
@@ -44,8 +44,13 @@ class SuspenseLoader<R> {
   }
 }
 
-const fetchSession = async (config: Config) =>
-  fetch(config.appUrl(internalClientSessionPath));
+const fetchSession = async (config: Config) => {
+  const result = await fetch(config.appUrl(internalClientSessionPath));
+  if (!result.ok && result.status > 400) {
+    throw InvalidSessionError;
+  }
+  return result;
+};
 
 export const internalSessionLoader = new SuspenseLoader<SessionResult>(
   fetchSession,
@@ -56,13 +61,18 @@ export const internalUserinfoLoader = new SuspenseLoader<UserInfo>(
     const resp = await fetchSession(config);
     const session = (await resp.json()) as unknown as SessionResult;
     if (session.token === "" || session.token === null) {
-      throw NoSessionError;
+      throw TokenUnavailableError;
     }
 
-    return await fetch(config.apiUrl(config.userInfoPath()), {
+    const result = await fetch(config.apiUrl(config.userInfoPath()), {
       headers: {
         Authorization: `Bearer ${session.token}`,
       },
     });
+    if (!result.ok && result.status > 400) {
+      throw InvalidSessionError;
+    }
+
+    return result;
   },
 );

--- a/packages/auth/src/core/loader.ts
+++ b/packages/auth/src/core/loader.ts
@@ -54,6 +54,10 @@ export const internalUserinfoLoader = new SuspenseLoader<UserInfo>(
   async (config) => {
     const resp = await fetchSession(config);
     const session = (await resp.json()) as unknown as SessionResult;
+    if (session.token === "" || session.token === null) {
+      throw new Error("No session token available");
+    }
+
     return await fetch(config.apiUrl(config.userInfoPath()), {
       headers: {
         Authorization: `Bearer ${session.token}`,

--- a/packages/auth/src/core/loader.ts
+++ b/packages/auth/src/core/loader.ts
@@ -1,6 +1,7 @@
 import { internalClientSessionPath } from "@core/path";
 import { Config } from "@core/config";
-import { NoSessionError, SessionResult, UserInfo } from "@core/types";
+import { SessionResult, UserInfo } from "@core/types";
+import { NoSessionError } from "@core/errors";
 
 // SuspenseLoader is a class that abstracts out the logic of loading a resource from a remote server,
 // and caches the result for React Suspense support in client components.

--- a/packages/auth/src/core/strategies/abstract.ts
+++ b/packages/auth/src/core/strategies/abstract.ts
@@ -131,10 +131,7 @@ export const oidcParamsError = () =>
     "code and redirectURI should be filled",
   );
 export const samlParamsError = () =>
-  new CallbackError(
-    "saml-invalid-params",
-    "SAMLResponse and RelayState should be filled",
-  );
+  new CallbackError("saml-invalid-params", "SAMLResponse should be filled");
 export const minitailorParamsError = () =>
   new CallbackError(
     "minitailor-invalid-params",

--- a/packages/auth/src/core/strategies/abstract.ts
+++ b/packages/auth/src/core/strategies/abstract.ts
@@ -143,7 +143,7 @@ export const minitailorParamsError = () =>
 export const minitailorTokenError = (code: number) =>
   new CallbackError(
     "minitailor-token-error",
-    `Failed to obtain token status=${code}`,
+    `failed to obtain token (status=${code})`,
   );
 
 /** @deprecated for backward compatibility use **Error */

--- a/packages/auth/src/core/strategies/abstract.ts
+++ b/packages/auth/src/core/strategies/abstract.ts
@@ -118,10 +118,11 @@ export type AbstractStrategy<
 
 export class CallbackError extends Error {
   constructor(
-    readonly name: string,
+    readonly code: string,
     readonly message: string,
   ) {
     super(message);
+    this.name = this.constructor.name;
   }
 }
 

--- a/packages/auth/src/core/strategies/abstract.ts
+++ b/packages/auth/src/core/strategies/abstract.ts
@@ -122,7 +122,7 @@ export class CallbackError extends Error {
     readonly message: string,
   ) {
     super(message);
-    this.name = this.constructor.name;
+    this.name = "CallbackError";
   }
 }
 

--- a/packages/auth/src/core/strategies/saml.ts
+++ b/packages/auth/src/core/strategies/saml.ts
@@ -27,8 +27,10 @@ export class SAMLStrategy implements AbstractStrategy<Options> {
   async callback(config: Config, request: Request) {
     const formData = await request.formData();
     const samlResponse = formData.get("SAMLResponse");
-    const readyState = formData.get("RelayState");
-    if (!samlResponse || !readyState) {
+    const relayState = formData.get("RelayState");
+
+    // RelayState will be optional in IDP initiated SAML flow
+    if (!samlResponse) {
       throw samlParamsError();
     }
 
@@ -40,7 +42,7 @@ export class SAMLStrategy implements AbstractStrategy<Options> {
 
     return {
       payload,
-      redirectUri: readyState ?? "/",
+      redirectUri: relayState ?? "/",
     } as CallbackResult;
   }
 }

--- a/packages/auth/src/core/types.ts
+++ b/packages/auth/src/core/types.ts
@@ -27,3 +27,5 @@ export type UserInfo = {
   family_name: string;
   email: string;
 };
+
+export const NoSessionError = new Error("No session available");

--- a/packages/auth/src/core/types.ts
+++ b/packages/auth/src/core/types.ts
@@ -27,5 +27,3 @@ export type UserInfo = {
   family_name: string;
   email: string;
 };
-
-export const NoSessionError = new Error("No session available");

--- a/packages/auth/src/server/middleware.test.ts
+++ b/packages/auth/src/server/middleware.test.ts
@@ -101,7 +101,7 @@ describe("error redirection", () => {
 
       expect(redirection.status).toBe(301);
       expect(redirection.headers.get("location")).toBe(
-        "http://localhost:3000/unauthorized?name=unknown-error",
+        "http://localhost:3000/unauthorized?code=unknown-error",
       );
     });
 
@@ -115,7 +115,7 @@ describe("error redirection", () => {
 
       expect(redirection.status).toBe(301);
       expect(redirection.headers.get("location")).toBe(
-        "http://localhost:3000/unauthorized?name=test-callback-error",
+        "http://localhost:3000/unauthorized?code=test-callback-error",
       );
     });
   });

--- a/packages/auth/src/server/middleware.test.ts
+++ b/packages/auth/src/server/middleware.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { middlewareRouter } from "./middleware";
+import { createErrorRedirection, middlewareRouter } from "./middleware";
 import { mockAuthConfig } from "@tests/mocks";
 import { buildRequestWithParams } from "@tests/helper";
+import { CallbackError } from "@core/strategies/abstract";
 
 describe("middleware", () => {
   const testingError = new Error("this is testing error");
@@ -87,6 +88,35 @@ describe("middleware", () => {
       ).not.toThrowError();
       expect(mockFallback).toHaveBeenCalled();
       expect(mockHandler).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("error redirection", () => {
+  describe("createErrorRedirection", () => {
+    it("creates a redirection with unknown error", () => {
+      const error = new Error("test error");
+      const config = mockAuthConfig;
+      const redirection = createErrorRedirection(config, error);
+
+      expect(redirection.status).toBe(301);
+      expect(redirection.headers.get("location")).toBe(
+        "http://localhost:3000/unauthorized?name=unknown-error",
+      );
+    });
+
+    it("creates a redirection with specific callback error", () => {
+      const error = new CallbackError(
+        "test-callback-error",
+        "this is an testing callback error",
+      );
+      const config = mockAuthConfig;
+      const redirection = createErrorRedirection(config, error);
+
+      expect(redirection.status).toBe(301);
+      expect(redirection.headers.get("location")).toBe(
+        "http://localhost:3000/unauthorized?name=test-callback-error",
+      );
     });
   });
 });

--- a/packages/auth/src/server/middleware.ts
+++ b/packages/auth/src/server/middleware.ts
@@ -13,6 +13,7 @@ import {
   internalUnauthorizedPath,
   internalLogoutPath,
 } from "@core/path";
+import { CallbackError } from "@core/strategies/abstract";
 
 export type MiddlewareHandlerOptions = {
   /**
@@ -103,7 +104,7 @@ export const middlewareRouter = async (
   routes: Record<string, RouteHandler>,
   fallback?: () => Promise<void>,
 ) => {
-  const { request, options } = params;
+  const { request, config, options } = params;
 
   try {
     const routeKey = Object.keys(routes).find((route) =>
@@ -123,7 +124,28 @@ export const middlewareRouter = async (
   } catch (e: unknown) {
     if (e instanceof Error && options?.onError) {
       await options.onError(e);
-      return NextResponse.next();
     }
+    return createErrorRedirection(config, e);
+  }
+};
+
+export const createErrorRedirection = (config: Config, e: unknown) => {
+  const redirectPath = config.unauthorizedPath();
+  const queryParams = new URLSearchParams({
+    name: extractErrorName(e),
+  });
+
+  // Direction always uses 301 to make it GET request to the destination page
+  return NextResponse.redirect(
+    config.appUrl(redirectPath) + "?" + queryParams.toString(),
+    301,
+  );
+};
+
+const extractErrorName = (e: unknown) => {
+  if (e instanceof CallbackError) {
+    return e.name;
+  } else {
+    return "unknown-error";
   }
 };

--- a/packages/auth/src/server/middleware.ts
+++ b/packages/auth/src/server/middleware.ts
@@ -132,7 +132,7 @@ export const middlewareRouter = async (
 export const createErrorRedirection = (config: Config, e: unknown) => {
   const redirectPath = config.unauthorizedPath();
   const queryParams = new URLSearchParams({
-    name: extractErrorName(e),
+    code: extractErrorCode(e),
   });
 
   // Direction always uses 301 to make it GET request to the destination page
@@ -142,9 +142,9 @@ export const createErrorRedirection = (config: Config, e: unknown) => {
   );
 };
 
-const extractErrorName = (e: unknown) => {
+const extractErrorCode = (e: unknown) => {
   if (e instanceof CallbackError) {
-    return e.name;
+    return e.code;
   } else {
     return "unknown-error";
   }


### PR DESCRIPTION
# Tickets

FL-163, FL-184, FL-173

# Background

* Auth package requests `userinfo` on platform even if `tailor.token` is invalid (null or empty), and it leads to `failed-exchange` error. 
* SAML strategy does not support IDP initiated flow that comes with an empty `RelayState`.

# Changes

This pull request primarily focuses on error handling and testing in the `packages/auth` directory. The most significant changes include adding a check for session token availability in `loader.ts`, modifying the error message in `abstract.ts`, importing `CallbackError` and `createErrorRedirection` in `middleware.test.ts`, and updating error handling in `middleware.ts`.

Error Handling:

* [`packages/auth/src/core/loader.ts`](diffhunk://#diff-8e986a4db2b146cea53c824b12f69e31b0f0e89605dc28a4c5bf8a7b70a09fd9R57-R60): Added a check to throw an error when the session token is empty or null in `internalUserinfoLoader`.
* [`packages/auth/src/core/strategies/abstract.ts`](diffhunk://#diff-fdd28aa80995655ae8d74435ce10f1bbd8304cd903706bebd5a85cdf59f53dd5L146-R146): Modified the error message in `minitailorTokenError` to include parentheses around the status code.
* [`packages/auth/src/server/middleware.ts`](diffhunk://#diff-2e090b44c7a207269efd9a4f21be7e8dfee962b26bb9e32fda4fb269a1eae3d7R16): Imported `CallbackError` from `@core/strategies/abstract` and added `createErrorRedirection` function to handle error redirection. Also, updated `middlewareRouter` to use `createErrorRedirection` when an error occurs. [[1]](diffhunk://#diff-2e090b44c7a207269efd9a4f21be7e8dfee962b26bb9e32fda4fb269a1eae3d7R16) [[2]](diffhunk://#diff-2e090b44c7a207269efd9a4f21be7e8dfee962b26bb9e32fda4fb269a1eae3d7L106-R107) [[3]](diffhunk://#diff-2e090b44c7a207269efd9a4f21be7e8dfee962b26bb9e32fda4fb269a1eae3d7L126-R149)

Testing:

* [`packages/auth/src/server/middleware.test.ts`](diffhunk://#diff-ac3a685ed06c7fd9860da52ef5310f7ee67e0d6defa0ca548ef041d520a18194L2-R5): Imported `createErrorRedirection` and `CallbackError` from `@core/strategies/abstract`. Added tests for `createErrorRedirection` to check redirection status and location for both unknown errors and specific callback errors. [[1]](diffhunk://#diff-ac3a685ed06c7fd9860da52ef5310f7ee67e0d6defa0ca548ef041d520a18194L2-R5) [[2]](diffhunk://#diff-ac3a685ed06c7fd9860da52ef5310f7ee67e0d6defa0ca548ef041d520a18194R94-R122)
