### PR TITLE
fix(ds): change initialFilterRows from usememo to useCallback

### DIFF
--- a/apps/storybook/src/stories/datagrid/DataGridWithFilterStory.tsx
+++ b/apps/storybook/src/stories/datagrid/DataGridWithFilterStory.tsx
@@ -23,7 +23,7 @@ export const DataGridWithFilterStory = ({
 }: DataGridWithFilterStoryProps) => {
   const [data, setData] = useState<Payment[]>(originData);
   const query: GraphQLQueryFilter = {
-    updatedAt: { eq: "2024-05-10 12:00:00" },
+    status: { eq: "pending" },
   };
   const defaultQuery: GraphQLQueryFilter = {
     amount: { gt: 200 },

--- a/apps/storybook/src/stories/datagrid/utils.ts
+++ b/apps/storybook/src/stories/datagrid/utils.ts
@@ -5,7 +5,7 @@ import {
 import { Payment } from "../../types/datagrid";
 
 export const setFilterChange = (
-  filter: GraphQLQueryFilter,
+  filter: GraphQLQueryFilter | undefined,
   data: Payment[],
   setData: React.Dispatch<React.SetStateAction<Payment[]>>,
 ) => {

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.test.tsx
@@ -154,6 +154,70 @@ describe("useCustomFilter", () => {
     expect(result.current.filterRows).toStrictEqual(expectedValue);
   });
 
+  it("clearFilterHandler work as expected with defaultFilter", () => {
+    const { result } = renderHook(() =>
+      useCustomFilter({
+        columns,
+        onChange: () => {
+          return;
+        },
+        systemFilter: undefined,
+        defaultFilter: { status: { eq: "pending" } },
+        localization: LOCALIZATION_JA,
+      }),
+    );
+
+    act(() => {
+      result.current.clearFilterHandler();
+    });
+
+    const expectedValue: FilterRowData[] = [
+      {
+        index: 0,
+        currentState: {
+          column: "",
+          value: "",
+          condition: "",
+          jointCondition: undefined,
+          isChangeable: true,
+        },
+      },
+    ];
+    expect(result.current.filterRows).toStrictEqual(expectedValue);
+  });
+
+  it("clearFilterHandler work as expected with defaultFilter and systemFilter", () => {
+    const { result } = renderHook(() =>
+      useCustomFilter({
+        columns,
+        onChange: () => {
+          return;
+        },
+        systemFilter: { status: { eq: "pending" } },
+        defaultFilter: { amount: { eq: 200 } },
+        localization: LOCALIZATION_JA,
+      }),
+    );
+
+    act(() => {
+      result.current.clearFilterHandler();
+    });
+
+    const expectedValue: FilterRowData[] = [
+      {
+        index: 0,
+        currentState: {
+          column: "",
+          value: "",
+          condition: "",
+          jointCondition: undefined,
+          isChangeable: true,
+        },
+      },
+    ];
+    expect(result.current.filterRows).toStrictEqual(expectedValue);
+  });
+
   it("deleteFilterRowHandler work as expected", async () => {
     const { result } = renderHook(() =>
       useCustomFilter({

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts
@@ -109,13 +109,14 @@ export const useCustomFilter = <TData>({
     [],
   );
 
-  const initialFilterRows: FilterRowData[] = useMemo(() => {
+  const initialFilterRows = useCallback((): FilterRowData[] => {
     const filterRows: FilterRowData[] = [];
     if (defaultFilter) {
       filterRows.push(
         ...convertQueryToFilterRows(defaultFilter, filterRows.length),
       );
     }
+
     filterRows.push(
       newEmptyRow({
         index: filterRows.length,
@@ -123,10 +124,10 @@ export const useCustomFilter = <TData>({
       }),
     );
     return filterRows;
-  }, [defaultFilter, newEmptyRow, convertQueryToFilterRows]);
+  }, [convertQueryToFilterRows, defaultFilter, newEmptyRow]);
 
   const [filterRows, setFilterRows] =
-    useState<FilterRowData[]>(initialFilterRows);
+    useState<FilterRowData[]>(initialFilterRows());
 
   /**
    * This will delete the filter row from filterRows.
@@ -154,9 +155,9 @@ export const useCustomFilter = <TData>({
    * This will reset the filterRows data state.
    */
   const clearFilterHandler = useCallback(() => {
-    setFilterRows([]);
+    setFilterRows([newEmptyRow({ index: 0, isChangeable: true })]);
     setSelectedJointCondition(undefined);
-  }, []);
+  }, [newEmptyRow]);
 
   /**
    * This will add new item to filterRows data state.


### PR DESCRIPTION
initialFilterRows used in resetFilter was the value of filterRows

<!-- Why is this change necessary, how it came to be? -->

# Changes

This pull request primarily focuses on improving the data grid filtering system in the `storybook` app and the `design-systems` package. The most significant changes include updating the default filter query in the `DataGridWithFilterStory`, making the filter parameter optional in `setFilterChange`, updating the version of the `design-systems` package, and modifying the `useCustomFilter` hook to use `useCallback` instead of `useMemo` for `initialFilterRows` and to update the `clearFilterHandler`.

Changes in the `storybook` app:

* [`apps/storybook/src/stories/datagrid/DataGridWithFilterStory.tsx`](diffhunk://#diff-2de5b29ead6c7733af1a3b86e9cc9989b01fb6ce2881bec14aae18ae3ee67e82L26-R26): The default filter query in the `DataGridWithFilterStory` has been updated to filter by `status` instead of `updatedAt`.
* [`apps/storybook/src/stories/datagrid/utils.ts`](diffhunk://#diff-24ac253e2db33b789d62ac00120b726c85986a2f410660df1ec3ed8874d9d98cL8-R8): The `filter` parameter in the `setFilterChange` function can now be `undefined`, allowing for more flexibility in usage.

Changes in the `design-systems` package:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the `design-systems` package has been updated from `0.31.1` to `0.31.2`.
* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts`](diffhunk://#diff-35b3c6fcdd195e366afc62165424a019f1d0061113720eb4b1cabef7ccb92f22L112-R130): The `useCustomFilter` hook has been modified to use `useCallback` instead of `useMemo` for `initialFilterRows` and to update the `clearFilterHandler` to always include a new empty row when it's called. This improves the user experience by always providing an empty row for input after the filters have been cleared. [[1]](diffhunk://#diff-35b3c6fcdd195e366afc62165424a019f1d0061113720eb4b1cabef7ccb92f22L112-R130) [[2]](diffhunk://#diff-35b3c6fcdd195e366afc62165424a019f1d0061113720eb4b1cabef7ccb92f22L157-R160)