### PR TITLE
fix(ds): change filter trigger event from onChange to onBlur

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
@@ -1011,6 +1011,161 @@ describe(
         });
       });
     });
+    it("after setting an input type filter, when changing the column, the input value is empty", async () => {
+      let currentFilters: GraphQLQueryFilter | undefined = undefined;
+
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter | undefined) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          customFilterOpen={true}
+          setCustomFilterOpen={() => void 0}
+          enableColumnFilters={true}
+        />,
+      );
+
+      const user = userEvent.setup();
+
+      // Open filter
+      await user.click(await screen.findByTestId("datagrid-filter-button"));
+
+      // Select column
+      const selectColumn = screen.getByTestId("select-column");
+      const selectColumnOptions = screen.getByTestId("select-column-options");
+      const selectColumnButton = within(selectColumn).getByRole("button");
+      await user.click(selectColumnButton);
+
+      const emailOption = within(selectColumnOptions).getByText("Email");
+      expect(emailOption).toBeVisible();
+
+      await user.click(emailOption);
+
+      expect(emailOption).not.toBeVisible();
+      expect(selectColumn).toHaveTextContent("Email");
+
+      // Select condition
+      const selectCondition = screen.getByTestId("select-condition");
+      const selectConditionOptions = screen.getByTestId(
+        "select-condition-options",
+      );
+      const selectConditionButton = within(selectCondition).getByRole("button");
+      await user.click(selectConditionButton);
+
+      const equalConditionOption = within(selectConditionOptions).getByText(
+        "等しい",
+      );
+      expect(equalConditionOption).toBeVisible();
+      expect(within(selectConditionOptions).getByText("含む")).toBeVisible();
+      expect(
+        within(selectConditionOptions).queryByText("等しくない"),
+      ).toBeNull();
+
+      await user.click(equalConditionOption);
+
+      expect(equalConditionOption).not.toBeVisible();
+      expect(selectCondition).toHaveTextContent("等しい");
+
+      const inputValue = screen.getByTestId("select-input-value");
+      await user.click(inputValue);
+      await user.type(inputValue, "test@test.com");
+      await user.click(equalConditionOption);
+
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual({
+          and: {
+            email: { eq: "test@test.com" },
+          },
+        });
+      });
+
+      await user.click(selectColumnButton);
+
+      const amountOption = within(selectColumnOptions).getByText("Amount");
+      expect(amountOption).toBeVisible();
+
+      await user.click(amountOption);
+
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual(undefined);
+      });
+    });
+    it("When the default filter for input type is set, when changing the column, the input value is empty", async () => {
+      let currentFilters: GraphQLQueryFilter | undefined = undefined;
+      const defaultQuery: GraphQLQueryFilter = {
+        email: { eq: "test@test.com" },
+      };
+
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter | undefined) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          customFilterOpen={true}
+          setCustomFilterOpen={() => void 0}
+          enableColumnFilters={true}
+          defaultFilter={defaultQuery}
+        />,
+      );
+
+      const user = userEvent.setup();
+
+      // Open filter
+      await user.click(await screen.findByTestId("datagrid-filter-button"));
+
+      // Select column
+      const selectColumn = screen.getAllByTestId("select-column")[0];
+      const selectColumnOptions = screen.getAllByTestId("select-column-options")[0];
+      const selectColumnButton = within(selectColumn).getByRole("button");
+      await user.click(selectColumnButton);
+      const amountOption = within(selectColumnOptions).getByText("Amount");
+      expect(amountOption).toBeVisible();
+
+      await user.click(amountOption);
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual(undefined);
+      });
+    });
+    it("When the default filter for input type is set, when clear filter, the input value is empty", async () => {
+      let currentFilters: GraphQLQueryFilter | undefined = undefined;
+      const defaultQuery: GraphQLQueryFilter = {
+        email: { eq: "test@test.com" },
+      };
+
+      render(
+        <CustomFilter
+          columns={columns}
+          onChange={(currentState: GraphQLQueryFilter | undefined) => {
+            currentFilters = currentState;
+          }}
+          localization={LOCALIZATION_JA}
+          customFilterOpen={true}
+          setCustomFilterOpen={() => void 0}
+          enableColumnFilters={true}
+          defaultFilter={defaultQuery}
+        />,
+      );
+
+      const user = userEvent.setup();
+
+      // Open filter
+      await user.click(await screen.findByTestId("datagrid-filter-button"));
+
+      // Clear filter
+      await user.click(screen.getByTestId("reset-clear-button"));
+
+      await waitFor(() => {
+        //Wait for the useEffect to update the filters
+        expect(currentFilters).toEqual(undefined);
+      });
+    });
   },
 
   { timeout: 10000 },

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
@@ -1121,7 +1121,9 @@ describe(
 
       // Select column
       const selectColumn = screen.getAllByTestId("select-column")[0];
-      const selectColumnOptions = screen.getAllByTestId("select-column-options")[0];
+      const selectColumnOptions = screen.getAllByTestId(
+        "select-column-options",
+      )[0];
       const selectColumnButton = within(selectColumn).getByRole("button");
       await user.click(selectColumnButton);
       const amountOption = within(selectColumnOptions).getByText("Amount");

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
@@ -1,11 +1,5 @@
 import { useState } from "react";
-import {
-  fireEvent,
-  render,
-  screen,
-  within,
-  waitFor,
-} from "@testing-library/react";
+import { render, screen, within, waitFor } from "@testing-library/react";
 import { ColumnDef } from "@tanstack/react-table";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
@@ -321,6 +315,8 @@ describe(
       const inputValue = screen.getByTestId("select-input-value");
       await user.click(inputValue);
       await user.type(inputValue, "test@test.com");
+      // trigger onBlur event
+      await user.click(equalConditionOption);
 
       expect(inputValue).toHaveValue("test@test.com");
 
@@ -392,7 +388,9 @@ describe(
 
       // Input value
       const inputValue = await screen.findByTestId("select-input-value");
-      fireEvent.change(inputValue, { target: { value: "800" } });
+      await user.type(inputValue, "800");
+      // trigger onBlur event
+      await user.click(equalConditionOption);
 
       expect(inputValue).toHaveValue(800);
 
@@ -461,6 +459,8 @@ describe(
       const inputValue = screen.getByTestId("select-input-value");
       await user.click(inputValue);
       await user.type(inputValue, "2023-11-14");
+      // trigger onBlur event
+      await user.click(selectConditionButton);
       expect(inputValue).toHaveValue("2023-11-14");
 
       //Check filters
@@ -708,6 +708,8 @@ describe(
       const inputValue = screen.getByTestId("select-input-value");
       await user.click(inputValue);
       await user.type(inputValue, "2023-11-14 23:00");
+      // trigger onBlur event
+      await user.click(lteConditionOption);
       expect(inputValue).toHaveValue("2023-11-14T23:00");
 
       //Check filters

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { CheckIcon, ChevronDown, X, XIcon } from "lucide-react";
 import { Select as AS, CollectionItem } from "@ark-ui/react/select";
 import { styled } from "@tailor-platform/styled-system/jsx";
@@ -62,6 +62,14 @@ export const FilterRow = <TData extends Record<string, unknown>>(
   } = props;
 
   const classes = select();
+
+  const [value, setValue] = useState<string[]>([
+    currentFilter.value.toString(),
+  ]);
+
+  useEffect(() => {
+    setValue([currentFilter.value.toString()]);
+  }, [currentFilter.value]);
 
   const DATE_INPUT_PLACEHOLDER = "YYYY-MM-DD";
   const filterConditions = getLocalizedFilterConditions(localization);
@@ -204,10 +212,13 @@ export const FilterRow = <TData extends Record<string, unknown>>(
             borderRadius={"4px"}
             variant="outline"
             placeholder={inputValuePlaceHolder}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {
               onChangeValue(e.target.value);
             }}
-            value={[currentFilter.value.toString()]}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setValue([e.target.value]);
+            }}
+            value={value}
             type={inputType} //This input element is used for date, dateTime, number and text type (for enum and boolean, we use select element above instead)
             maxLength={50}
           />

--- a/packages/design-systems/src/components/composite/Datagrid/utils/test/customFilter.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/utils/test/customFilter.ts
@@ -113,6 +113,9 @@ export const inputValue = async (
   const inputValue = screen.getAllByTestId("select-input-value")[valueIndex];
   await user.click(inputValue);
   await user.type(inputValue, value);
+  // trigger onBlur event
+  const selectCondition = screen.getAllByTestId("select-condition")[valueIndex];
+  await user.click(selectCondition);
 };
 
 /**


### PR DESCRIPTION
# Background

Change trigger event form onChange to onBlur

# Changes

This pull request involves updates to the `packages/design-systems` package, including a version bump, changes to the `CustomFilter.test.tsx` test file, and modifications to the `FilterRow.tsx` and `customFilter.ts` files. The key changes revolve around the handling of onBlur events, state management, and the removal of unused imports.

Version update:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The package version has been updated from 0.31.2 to 0.31.3.

Test updates:

* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx`](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL2-R2): Unused imports have been removed and the fireEvent.change method has been replaced with user.type. Additionally, onBlur events have been triggered in several test cases. [[1]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL2-R2) [[2]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcR318-R319) [[3]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcL395-R393) [[4]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcR462-R463) [[5]](diffhunk://#diff-7639ed2d86a4f46ee4ef496ff371b3ef6f083ec52dadc872fa2f28c7a774edfcR711-R712)

Component updates:

* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx`](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL1-R1): Added useState and useEffect hooks to manage the value state. The onChange event handler has been replaced with an onBlur event handler. [[1]](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL1-R1) [[2]](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dR66-R73) [[3]](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL207-R221)

Utility updates:

* [`packages/design-systems/src/components/composite/Datagrid/utils/test/customFilter.ts`](diffhunk://#diff-570a057ed0b3ec74fe77564e24b5184a963ba245342ff501bfcfbde79cb3a914R116-R118): Added a trigger for onBlur event after input value is typed.