### PR TITLE
fix(ds): fix behavior when systemFilter is empty object

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.test.tsx
@@ -523,6 +523,48 @@ describe("useCustomFilter", () => {
     });
   });
 
+  it("generateGraphQLQueryFilter works correctly with no filter", async () => {
+    const { result } = renderHook(() =>
+      useCustomFilter({
+        columns,
+        onChange: () => {
+          return;
+        },
+        systemFilter: undefined,
+        defaultFilter: undefined,
+        localization: LOCALIZATION_JA,
+      }),
+    );
+
+    const expectedValue = undefined;
+    act(() => {
+      expect(
+        result.current.generateGraphQLQueryFilter(result.current.filterRows),
+      ).toStrictEqual(expectedValue);
+    });
+  });
+
+  it("generateGraphQLQueryFilter works correctly with systemFilter which is empty object", async () => {
+    const { result } = renderHook(() =>
+      useCustomFilter({
+        columns,
+        onChange: () => {
+          return;
+        },
+        systemFilter: {},
+        defaultFilter: undefined,
+        localization: LOCALIZATION_JA,
+      }),
+    );
+
+    const expectedValue = undefined;
+    act(() => {
+      expect(
+        result.current.generateGraphQLQueryFilter(result.current.filterRows),
+      ).toStrictEqual(expectedValue);
+    });
+  });
+
   it("useEffect not called when prevFilter is same", async () => {
     const systemFilter = { status: { eq: "pending" } };
     const defaultFilter = { amount: { eq: 200 } };

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts
@@ -324,16 +324,15 @@ export const useCustomFilter = <TData>({
         }
       });
 
-      if (isNotEmpty(systemFilter) || isNotEmpty(newGraphQLQueryFilter)) {
-        return {
-          and: {
-            ...systemFilter,
-            ...newGraphQLQueryFilter,
-          },
-        };
-      } else {
+      if (isEmpty(systemFilter) && isEmpty(newGraphQLQueryFilter)) {
         return undefined;
       }
+      return {
+        and: {
+          ...systemFilter,
+          ...newGraphQLQueryFilter,
+        },
+      };
     },
     [systemFilter, columns, addToGraphQLQueryFilterRecursively, localization],
   );
@@ -401,7 +400,7 @@ export const useCustomFilter = <TData>({
   };
 };
 
-const isNotEmpty = (obj: object | undefined): boolean => {
-  if (obj === undefined) return false;
-  return Object.keys(obj).length > 0;
+const isEmpty = (obj: object | undefined): boolean => {
+  if (obj === undefined) return true;
+  return Object.keys(obj).length === 0;
 };

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts
@@ -324,18 +324,16 @@ export const useCustomFilter = <TData>({
         }
       });
 
-      if (!systemFilter && Object.keys(newGraphQLQueryFilter).length === 0) {
+      if (isNotEmpty(systemFilter) || isNotEmpty(newGraphQLQueryFilter)) {
+        return {
+          and: {
+            ...systemFilter,
+            ...newGraphQLQueryFilter,
+          },
+        };
+      } else {
         return undefined;
       }
-
-      const result = {
-        and: {
-          ...systemFilter,
-          ...newGraphQLQueryFilter,
-        },
-      };
-
-      return result;
     },
     [systemFilter, columns, addToGraphQLQueryFilterRecursively, localization],
   );
@@ -401,4 +399,9 @@ export const useCustomFilter = <TData>({
     initialFilterRows, // For testing purpose
     setPrevFilter, // For testing purpose
   };
+};
+
+const isNotEmpty = (obj: object | undefined): boolean => {
+  if (obj === undefined) return false;
+  return Object.keys(obj).length > 0;
 };


### PR DESCRIPTION
# Background
 
fix behavior when systemFilter is an object.

# Changes

This pull request primarily focuses on the `@tailor-platform/design-systems` package, with changes aimed at refining the `useCustomFilter` function and its associated tests. The changes include a version bump in the `package.json` file, the addition of new tests for the `useCustomFilter` function, and modifications to the `useCustomFilter` function itself to improve its handling of empty filter conditions.

Version Update:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the `@tailor-platform/design-systems` package has been incremented from `0.31.3` to `0.31.4`.

Testing Improvements:

* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.test.tsx`](diffhunk://#diff-23497eaff0d7e8e80a622b3ec3d53b7fe5532eab7c5170919360aef0fcf22d7dR526-R567): Two new test cases have been added to verify the behavior of the `generateGraphQLQueryFilter` function when no filter or an empty object is provided as the system filter.

Code Refactoring:

* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts`](diffhunk://#diff-35b3c6fcdd195e366afc62165424a019f1d0061113720eb4b1cabef7ccb92f22L327-R336): The condition for returning `undefined` from the function has been refactored. Instead of checking for the absence of `systemFilter` and an empty `newGraphQLQueryFilter`, it now uses a new helper function `isNotEmpty` to confirm that either `systemFilter` or `newGraphQLQueryFilter` has content before proceeding. This change simplifies the logic and makes the code more readable. [[1]](diffhunk://#diff-35b3c6fcdd195e366afc62165424a019f1d0061113720eb4b1cabef7ccb92f22L327-R336) [[2]](diffhunk://#diff-35b3c6fcdd195e366afc62165424a019f1d0061113720eb4b1cabef7ccb92f22R403-R407)
