### PR TITLE
fix(ds): fix duplicate id

### DIFF
--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.31.5-preview.6",
+  "version": "0.31.5",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.31.5-preview.5",
+  "version": "0.31.5",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.31.5-preview.3",
+  "version": "0.31.5-preview.4",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.31.5-preview.2",
+  "version": "0.31.5-preview.3",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.31.4",
+  "version": "0.31.5-preview.1",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.31.5",
+  "version": "0.31.5-preview.6",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.31.5-preview.1",
+  "version": "0.31.5-preview.2",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/package.json
+++ b/packages/design-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/design-systems",
-  "version": "0.31.5-preview.4",
+  "version": "0.31.5-preview.5",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/HideShow.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/HideShow.tsx
@@ -87,10 +87,10 @@ export const HideShow = <TData extends Record<string, unknown>>(
           gap="4"
           className={scrollBar()}
         >
-          {columns.map((column) => {
+          {columns.map((column, i) => {
             return (
               <Checkbox
-                key={column.id}
+                key={column.id + i}
                 checked={column.getIsVisible()}
                 onCheckedChange={(e: { checked: boolean }) =>
                   column.getToggleVisibilityHandler()({

--- a/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/HideShow.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/HideShow.tsx
@@ -90,7 +90,7 @@ export const HideShow = <TData extends Record<string, unknown>>(
           {columns.map((column, i) => {
             return (
               <Checkbox
-                key={column.id + i}
+                key={i}
                 checked={column.getIsVisible()}
                 onCheckedChange={(e: { checked: boolean }) =>
                   column.getToggleVisibilityHandler()({

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -245,7 +245,7 @@ export const DataGrid = <TData extends Record<string, unknown>>(
                   data-state={row.getIsSelected() && "selected"}
                   data-testid={`datagrid-row`}
                 >
-                  {row.getVisibleCells().map((cell) => {
+                  {row.getVisibleCells().map((cell, i) => {
                     if (
                       cell.column.columnDef.meta &&
                       cell.column.columnDef.meta.type === "enum"
@@ -256,7 +256,7 @@ export const DataGrid = <TData extends Record<string, unknown>>(
                       ] as ReactNode;
                       return (
                         <TableCell
-                          key={cell.id}
+                          key={cell.id + i}
                           className={tableDataClasses}
                           style={{
                             ...getCommonPinningStyles(cell.column),
@@ -275,7 +275,7 @@ export const DataGrid = <TData extends Record<string, unknown>>(
                     }
                     return (
                       <TableCell
-                        key={cell.id}
+                        key={cell.id + i}
                         className={tableDataClasses}
                         style={{
                           ...getCommonPinningStyles(cell.column),

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -213,14 +213,14 @@ export const DataGrid = <TData extends Record<string, unknown>>(
       <styled.div className={datagridClasses.wrapper}>
         <Table className={datagridClasses.table} overflow={"visible"}>
           <TableHeader className={datagridClasses.tableHeader}>
-            {table.getHeaderGroups().map((headerGroup) => (
+            {table.getHeaderGroups().map((headerGroup, i) => (
               <TableRow
                 className={datagridClasses.tableRow}
-                key={headerGroup.id}
+                key={i}
               >
                 {headerGroup.headers.map((header, i) => (
                   <TableHead
-                    key={header.id + i}
+                    key={i}
                     header={header as Header<Record<string, unknown>, unknown>}
                     table={table}
                     columnPiningStyles={getCommonPinningStyles(
@@ -238,10 +238,10 @@ export const DataGrid = <TData extends Record<string, unknown>>(
           </TableHeader>
           <TableBody className={datagridClasses.tableBody}>
             {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
+              table.getRowModel().rows.map((row, i) => (
                 <TableRow
                   className={datagridClasses.tableRow}
-                  key={row.id}
+                  key={i}
                   data-state={row.getIsSelected() && "selected"}
                   data-testid={`datagrid-row`}
                 >
@@ -256,7 +256,7 @@ export const DataGrid = <TData extends Record<string, unknown>>(
                       ] as ReactNode;
                       return (
                         <TableCell
-                          key={cell.id + i}
+                          key={i}
                           className={tableDataClasses}
                           style={{
                             ...getCommonPinningStyles(cell.column),
@@ -275,7 +275,7 @@ export const DataGrid = <TData extends Record<string, unknown>>(
                     }
                     return (
                       <TableCell
-                        key={cell.id + i}
+                        key={i}
                         className={tableDataClasses}
                         style={{
                           ...getCommonPinningStyles(cell.column),

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -218,9 +218,9 @@ export const DataGrid = <TData extends Record<string, unknown>>(
                 className={datagridClasses.tableRow}
                 key={headerGroup.id}
               >
-                {headerGroup.headers.map((header) => (
+                {headerGroup.headers.map((header, i) => (
                   <TableHead
-                    key={header.id}
+                    key={header.id + i}
                     header={header as Header<Record<string, unknown>, unknown>}
                     table={table}
                     columnPiningStyles={getCommonPinningStyles(

--- a/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx
@@ -214,10 +214,7 @@ export const DataGrid = <TData extends Record<string, unknown>>(
         <Table className={datagridClasses.table} overflow={"visible"}>
           <TableHeader className={datagridClasses.tableHeader}>
             {table.getHeaderGroups().map((headerGroup, i) => (
-              <TableRow
-                className={datagridClasses.tableRow}
-                key={i}
-              >
+              <TableRow className={datagridClasses.tableRow} key={i}>
                 {headerGroup.headers.map((header, i) => (
                   <TableHead
                     key={i}

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
@@ -74,10 +74,10 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
                 id="jointConditions"
                 data-testid="select-page-size-options"
               >
-                {pageSizeOptions.map((item) => (
+                {pageSizeOptions.map((item, i) => (
                   <Select.Item
                     className={classes.item}
-                    key={"pageSize" + item}
+                    key={i}
                     item={item}
                   >
                     <Select.ItemText className={classes.itemText}>
@@ -144,11 +144,11 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
         >
           <ChevronLeftIcon />
         </IconButton>
-        {pages.map((page, index) => {
+        {pages.map((page, i) => {
           if (page.type === "page") {
             return (
               <Button
-                key={"pageIndex" + index}
+                key={i}
                 variant={pageIndex === page.index ? "primary" : "secondary"}
                 aria-label="Number Page"
                 onClick={() => {
@@ -161,7 +161,7 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
             );
           } else {
             return (
-              <Text key={"pageIndex" + index} pb={4}>
+              <Text key={i} pb={4}>
                 …
               </Text>
             );

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/ManualPagination.tsx
@@ -75,11 +75,7 @@ export const ManualPagination = <TData extends Record<string, unknown>>({
                 data-testid="select-page-size-options"
               >
                 {pageSizeOptions.map((item, i) => (
-                  <Select.Item
-                    className={classes.item}
-                    key={i}
-                    item={item}
-                  >
+                  <Select.Item className={classes.item} key={i} item={item}>
                     <Select.ItemText className={classes.itemText}>
                       {item}
                     </Select.ItemText>

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
@@ -69,11 +69,7 @@ export const Pagination = <TData extends Record<string, unknown>>({
                 data-testid="select-page-size-options"
               >
                 {pageSizeOptions.map((item, i) => (
-                  <Select.Item
-                    className={classes.item}
-                    key={i}
-                    item={item}
-                  >
+                  <Select.Item className={classes.item} key={i} item={item}>
                     <Select.ItemText className={classes.itemText}>
                       {item}
                     </Select.ItemText>

--- a/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/Pagination/Pagination.tsx
@@ -68,10 +68,10 @@ export const Pagination = <TData extends Record<string, unknown>>({
                 id="jointConditions"
                 data-testid="select-page-size-options"
               >
-                {pageSizeOptions.map((item) => (
+                {pageSizeOptions.map((item, i) => (
                   <Select.Item
                     className={classes.item}
-                    key={"pageSize" + item}
+                    key={i}
                     item={item}
                   >
                     <Select.ItemText className={classes.itemText}>
@@ -136,11 +136,11 @@ export const Pagination = <TData extends Record<string, unknown>>({
         >
           <ChevronLeftIcon />
         </IconButton>
-        {pages.map((page, index) => {
+        {pages.map((page, i) => {
           if (page.type === "page") {
             return (
               <Button
-                key={"pageIndex" + index}
+                key={i}
                 variant={pageIndex === page.index ? "primary" : "secondary"}
                 aria-label="Number Page"
                 onClick={() => {
@@ -152,7 +152,7 @@ export const Pagination = <TData extends Record<string, unknown>>({
             );
           } else {
             return (
-              <Text key={"pageIndex" + index} pb={4}>
+              <Text key={i} pb={4}>
                 …
               </Text>
             );

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.tsx
@@ -119,7 +119,7 @@ export const CustomFilter = <TData extends Record<string, unknown>>(
           {filterRows.map((row, i) => {
             return (
               <FilterRow
-                key={"filterRow" + i}
+                key={i}
                 currentFilter={row.currentState}
                 columns={columns}
                 jointConditions={activeJointConditions}

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
@@ -278,10 +278,10 @@ export const FilterRow = <TData extends Record<string, unknown>>(
               id="jointConditions"
               data-testid="select-joint-condition-options"
             >
-              {jointConditions.map((item, i) => (
+              {jointConditions.map((item) => (
                 <Select.Item
                   className={classes.item}
-                  key={item.value + i}
+                  key={item.value}
                   item={item}
                   data-testid={`joint-condition-${item.value}`}
                 >
@@ -332,10 +332,10 @@ export const FilterRow = <TData extends Record<string, unknown>>(
             data-testid="select-column-options"
           >
             <Select.ItemGroup className={classes.itemGroup} id="column">
-              {columns.map((item) => (
+              {columns.map((item, i) => (
                 <Select.Item
                   className={classes.item}
-                  key={item.value}
+                  key={item.value + i}
                   item={item}
                   data-testid={`filter-column-${item.value}`}
                 >

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
@@ -278,10 +278,10 @@ export const FilterRow = <TData extends Record<string, unknown>>(
               id="jointConditions"
               data-testid="select-joint-condition-options"
             >
-              {jointConditions.map((item) => (
+              {jointConditions.map((item, i) => (
                 <Select.Item
                   className={classes.item}
-                  key={item.value}
+                  key={i}
                   item={item}
                   data-testid={`joint-condition-${item.value}`}
                 >
@@ -335,7 +335,7 @@ export const FilterRow = <TData extends Record<string, unknown>>(
               {columns.map((item, i) => (
                 <Select.Item
                   className={classes.item}
-                  key={item.value + i}
+                  key={i}
                   item={item}
                   data-testid={`filter-column-${item.value}`}
                 >
@@ -386,10 +386,10 @@ export const FilterRow = <TData extends Record<string, unknown>>(
             data-testid="select-condition-options"
           >
             <Select.ItemGroup className={classes.itemGroup} id="condition">
-              {filteredFilterConditions.map((item) => (
+              {filteredFilterConditions.map((item, i) => (
                 <Select.Item
                   className={classes.item}
-                  key={item.value}
+                  key={i}
                   item={item}
                 >
                   <Select.ItemText className={classes.itemText}>
@@ -541,10 +541,10 @@ const EnumSelect = <TData extends Record<string, unknown>>({
             data-testid="select-input-value-options"
           >
             <Select.ItemGroup className={classes.itemGroup} id="filterByValue">
-              {enumList.map((item) => {
+              {enumList.map((item, i) => {
                 const enumValue = selectedColumnObject?.meta?.enumType?.[item];
                 return (
-                  <Select.Item className={classes.item} key={item} item={item}>
+                  <Select.Item className={classes.item} key={i} item={item}>
                     <Select.ItemText className={classes.itemText}>
                       {enumValue}
                     </Select.ItemText>

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
@@ -387,11 +387,7 @@ export const FilterRow = <TData extends Record<string, unknown>>(
           >
             <Select.ItemGroup className={classes.itemGroup} id="condition">
               {filteredFilterConditions.map((item, i) => (
-                <Select.Item
-                  className={classes.item}
-                  key={i}
-                  item={item}
-                >
+                <Select.Item className={classes.item} key={i} item={item}>
                   <Select.ItemText className={classes.itemText}>
                     {item.label}
                   </Select.ItemText>

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
@@ -278,10 +278,10 @@ export const FilterRow = <TData extends Record<string, unknown>>(
               id="jointConditions"
               data-testid="select-joint-condition-options"
             >
-              {jointConditions.map((item) => (
+              {jointConditions.map((item, i) => (
                 <Select.Item
                   className={classes.item}
-                  key={item.value}
+                  key={item.value + i}
                   item={item}
                   data-testid={`joint-condition-${item.value}`}
                 >

--- a/packages/design-systems/src/components/composite/PinInput.tsx
+++ b/packages/design-systems/src/components/composite/PinInput.tsx
@@ -24,11 +24,7 @@ export const PinInput = (props: PinInputProps) => {
     >
       <ArkPinInput.Control className={classes.control}>
         {[...(Array(digits) as number[])].map((_, i) => (
-          <ArkPinInput.Input
-            key={i}
-            index={i}
-            className={classes.input}
-          />
+          <ArkPinInput.Input key={i} index={i} className={classes.input} />
         ))}
       </ArkPinInput.Control>
     </ArkPinInput.Root>

--- a/packages/design-systems/src/components/composite/PinInput.tsx
+++ b/packages/design-systems/src/components/composite/PinInput.tsx
@@ -23,10 +23,10 @@ export const PinInput = (props: PinInputProps) => {
       {...rest}
     >
       <ArkPinInput.Control className={classes.control}>
-        {[...(Array(digits) as number[])].map((_, index) => (
+        {[...(Array(digits) as number[])].map((_, i) => (
           <ArkPinInput.Input
-            key={"pininput" + index}
-            index={index}
+            key={i}
+            index={i}
             className={classes.input}
           />
         ))}

--- a/packages/design-systems/src/components/composite/RadioGroup.tsx
+++ b/packages/design-systems/src/components/composite/RadioGroup.tsx
@@ -35,10 +35,10 @@ export const RadioGroup = (props: RadioGroupProps) => {
       }
       {...rest}
     >
-      {options.map((option) => (
+      {options.map((option, i) => (
         <ArkRadioGroup.Item
           className={classes.item}
-          key={"radio" + option.value}
+          key={i}
           value={option.value}
           disabled={option.disabled}
         >


### PR DESCRIPTION
# Background

An error occurred due to duplicate id.

# Changes

This pull request primarily focuses on two aspects: updating the version of the `design-systems` package and enhancing the keys used in several map functions within various components of the `design-systems` package. The keys for map functions have been changed to be a combination of the original key and the index, which should help ensure unique keys and prevent potential issues with React rendering.

Version Update:

* [`packages/design-systems/package.json`](diffhunk://#diff-b3c3ba59c3ba445b0f4075c962272f6058d02fa85b06b8732963cba1b4aa7cf9L3-R3): The version of the `design-systems` package has been updated from `0.31.4` to `0.31.5`.

Key Enhancements:

* [`packages/design-systems/src/components/composite/Datagrid/ColumnFeature/HideShow.tsx`](diffhunk://#diff-2f9f3d84fe04ff051833f187c2ba040c7d5b934354dc28d0cfd3ddd269081553L90-R93): The key used in the `columns.map` function has been modified to be a combination of `column.id` and the index.
* [`packages/design-systems/src/components/composite/Datagrid/Datagrid.tsx`](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL221-R223): The keys used in the `headerGroup.headers.map`, `row.getVisibleCells().map`, and another `row.getVisibleCells().map` functions have been changed to be a combination of the original key and the index. [[1]](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL221-R223) [[2]](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL248-R248) [[3]](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL259-R259) [[4]](diffhunk://#diff-df05b9030c0841de2c2cbf61a9e558434a1a78776196cd38d0b77e824095af7cL278-R278)
* [`packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx`](diffhunk://#diff-56db058386255780559894d672519e6184661b4a213ed38ed8cd826fee542b8dL335-R338): The key used in the `columns.map` function has been modified to be a combination of `item.value` and the index.