### PR TITLE
chore: comment chromatic preview url on pull request

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,7 +1,8 @@
 name: Chromatic Deployment
 
 on:
-  push:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
     paths:
       - apps/storybook/**
       - packages/design-systems/**
@@ -24,8 +25,21 @@ jobs:
         with:
           scope: storybook
 
-      - name: Publish storybook to chromatic
-        run: pnpm run chromatic
+      - name: Prepare css for storybook
+        run: pnpm run panda
         working-directory: ./apps/storybook
-        env:
-          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+
+      - name: Publish storybook to chromatic
+        id: chromatic
+        uses: chromaui/action@v11
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: apps/storybook
+          exitZeroOnChanges: true
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: chromatic-url
+          message: |
+            Storybook preview URL (for ${{ github.sha }}): <${{ steps.chromatic.outputs.storybookUrl }}>
+            <sub>Build URL: ${{ steps.chromatic.outputs.buildUrl }}</sub>

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -25,10 +25,6 @@ jobs:
         with:
           scope: storybook
 
-      - name: Prepare css for storybook
-        run: pnpm run panda
-        working-directory: ./apps/storybook
-
       - name: Publish storybook to chromatic
         id: chromatic
         uses: chromaui/action@v11

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -10,7 +10,6 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "panda": "panda codegen",
-    "chromatic": "pnpm panda && chromatic --exit-zero-on-changes",
     "ark:types": "node --loader ts-node/esm/transpile-only ./scripts/generate-ark-types.ts",
     "storybook:types": "node --loader ts-node/esm/transpile-only ./scripts/generate-storybook-types.ts",
     "ark:storybook:types": "pnpm ark:types && pnpm storybook:types"


### PR DESCRIPTION
# Background

<!-- Why is this change necessary, how it came to be? -->
When updating the design system, the Storybook preview url is only in the CI log detail.

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
The URLs for the Storybook preview can be found in a comment on Pull Requests.