### PR TITLE
refactor(ds): in FilterRow, use localization only for UI label

### DIFF
--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.tsx
@@ -46,7 +46,6 @@ export const CustomFilter = <TData extends Record<string, unknown>>(
   } = useCustomFilter({
     columns,
     onChange,
-    localization,
     systemFilter,
     defaultFilter,
   });

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/FilterRow.tsx
@@ -198,7 +198,16 @@ export const FilterRow = <TData extends Record<string, unknown>>(
           currentFilter={currentFilter}
           inputValuePlaceHolder={inputValuePlaceHolder}
           onChangeValue={onChangeValue}
-          localization={localization}
+          items={[
+            {
+              label: localization.filter.columnBoolean.true,
+              value: "true",
+            },
+            {
+              label: localization.filter.columnBoolean.false,
+              value: "false",
+            },
+          ]}
         />
       );
     } else {
@@ -562,13 +571,13 @@ type BooleanSelectProps = {
   currentFilter: FilterRowState;
   onChangeValue: (value: string[]) => void;
   inputValuePlaceHolder: string;
-  localization: Localization;
+  items: { label: string; value: string }[];
 };
 const BooleanSelect = ({
   currentFilter,
   onChangeValue,
   inputValuePlaceHolder,
-  localization,
+  items,
 }: BooleanSelectProps) => {
   const classes = select();
 
@@ -576,23 +585,14 @@ const BooleanSelect = ({
     <>
       <Select.Root
         className={classes.root}
-        items={[
-          localization.filter.columnBoolean.true,
-          localization.filter.columnBoolean.false,
-        ]}
+        items={items}
         positioning={{ sameWidth: true }}
         closeOnSelect
         width={180}
         onValueChange={(e: ValueChangeDetails<CollectionItem>) =>
           onChangeValue(e.value)
         }
-        value={[
-          currentFilter.value.toString() === "true" ||
-          currentFilter.value.toString() ===
-            localization.filter.columnBoolean.true
-            ? localization.filter.columnBoolean.true
-            : localization.filter.columnBoolean.false,
-        ]}
+        value={[currentFilter.value.toString()]}
         data-testid="select-input-value"
       >
         <Select.Control className={classes.control}>
@@ -608,30 +608,18 @@ const BooleanSelect = ({
         <Select.Positioner className={classes.positioner}>
           <Select.Content className={classes.content}>
             <Select.ItemGroup className={classes.itemGroup} id="filterByValue">
-              <Select.Item
-                className={classes.item}
-                key={"selectInput" + 0}
-                item={localization.filter.columnBoolean.true}
-              >
-                <Select.ItemText className={classes.itemText}>
-                  {localization.filter.columnBoolean.true}
-                </Select.ItemText>
-                <Select.ItemIndicator className={classes.itemIndicator}>
-                  <CheckIcon />
-                </Select.ItemIndicator>
-              </Select.Item>
-              <Select.Item
-                className={classes.item}
-                key={"selectInput" + 1}
-                item={localization.filter.columnBoolean.false}
-              >
-                <Select.ItemText className={classes.itemText}>
-                  {localization.filter.columnBoolean.false}
-                </Select.ItemText>
-                <Select.ItemIndicator className={classes.itemIndicator}>
-                  <CheckIcon />
-                </Select.ItemIndicator>
-              </Select.Item>
+              {items.map((item, i) => {
+                return (
+                  <Select.Item className={classes.item} key={i} item={item}>
+                    <Select.ItemText className={classes.itemText}>
+                      {item.label}
+                    </Select.ItemText>
+                    <Select.ItemIndicator className={classes.itemIndicator}>
+                      <CheckIcon />
+                    </Select.ItemIndicator>
+                  </Select.Item>
+                );
+              })}
             </Select.ItemGroup>
           </Select.Content>
         </Select.Positioner>

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.test.tsx
@@ -1,7 +1,6 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { columns } from "../utils/test";
-import { LOCALIZATION_JA } from "../../../../locales/ja";
 import { FilterRowData, useCustomFilter } from "./useCustomFilter";
 import { FilterRowState, GraphQLQueryFilter, QueryRow } from "./types";
 
@@ -16,7 +15,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: { status: { eq: "pending" } },
           defaultFilter: undefined,
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -48,7 +46,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: undefined,
           defaultFilter: undefined,
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -80,7 +77,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: undefined,
           defaultFilter: { status: { eq: "pending" } },
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -122,7 +118,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: { status: { eq: "pending" } },
           defaultFilter: { amount: { eq: 200 } },
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -166,7 +161,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: undefined,
           defaultFilter: { status: { eq: "pending" } },
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -198,7 +192,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: { status: { eq: "pending" } },
           defaultFilter: { amount: { eq: 200 } },
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -232,7 +225,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: undefined,
           defaultFilter: undefined,
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -274,7 +266,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: systemFilter,
           defaultFilter: defaultFilter,
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -355,7 +346,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: undefined,
           defaultFilter: defaultFilter,
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -410,7 +400,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: undefined,
           defaultFilter: defaultFilter,
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -463,7 +452,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: undefined,
           defaultFilter: defaultFilter,
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -514,7 +502,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: systemFilter,
           defaultFilter: undefined,
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -546,7 +533,6 @@ describe("useCustomFilter", () => {
             return;
           },
           defaultFilter: defaultFilter,
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -590,7 +576,6 @@ describe("useCustomFilter", () => {
           },
           systemFilter: systemFilter,
           defaultFilter: defaultFilter,
-          localization: LOCALIZATION_JA,
         }),
       );
 
@@ -632,7 +617,6 @@ describe("useCustomFilter", () => {
         onChange: (filter) => {
           currentFilter = filter;
         },
-        localization: LOCALIZATION_JA,
       }),
     );
 
@@ -650,7 +634,6 @@ describe("useCustomFilter", () => {
         },
         systemFilter: { status: { eq: "pending" } },
         defaultFilter: { amount: { eq: 200 } },
-        localization: LOCALIZATION_JA,
       }),
     );
 
@@ -696,7 +679,6 @@ describe("useCustomFilter", () => {
         onChange: onChangeMock,
         systemFilter: systemFilter,
         defaultFilter: defaultFilter,
-        localization: LOCALIZATION_JA,
       }),
     );
 

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts
@@ -20,7 +20,6 @@ export type FilterRowData = {
 type UseCustomFilterProps<TData> = {
   columns: Array<Column<TData>>;
   onChange: (currentState: GraphQLQueryFilter | undefined) => void;
-  localization: Localization;
   systemFilter?: QueryRow;
   defaultFilter?: QueryRow;
 };
@@ -28,7 +27,6 @@ type UseCustomFilterProps<TData> = {
 export const useCustomFilter = <TData>({
   columns,
   onChange,
-  localization,
   systemFilter,
   defaultFilter,
 }: UseCustomFilterProps<TData>) => {
@@ -39,7 +37,6 @@ export const useCustomFilter = <TData>({
   >(undefined);
   const { generateFilter } = useGraphQLQuery({
     columns,
-    localization,
     systemFilter,
   });
 

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useCustomFilter.ts
@@ -6,7 +6,7 @@ import {
   useRef,
   CSSProperties,
 } from "react";
-import type { GraphQLQueryFilter, Localization } from "..";
+import type { GraphQLQueryFilter } from "..";
 import type { Column } from "../types";
 import { jointConditions } from "./filter";
 import { FilterRowState, JointCondition, QueryRow } from "./types";

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useGraphQLQuery.test.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useGraphQLQuery.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import { columns } from "../utils/test";
 import { useGraphQLQuery } from "./useGraphQLQuery";
 import { QueryRow, FilterRowState } from "./types";
-import { LOCALIZATION_JA } from "@locales";
 
 describe("useGraphQLQuery", () => {
   it("addToGraphQLQueryFilterRecursively work as expected with jointCondition", async () => {

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useGraphQLQuery.test.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useGraphQLQuery.test.ts
@@ -11,7 +11,6 @@ describe("useGraphQLQuery", () => {
       useGraphQLQuery({
         columns,
         systemFilter: { status: { eq: "pending" } },
-        localization: LOCALIZATION_JA,
       }),
     );
     const graphQLQueryObject: QueryRow = {};
@@ -45,7 +44,6 @@ describe("useGraphQLQuery", () => {
       useGraphQLQuery({
         columns,
         systemFilter: { status: { eq: "pending" } },
-        localization: LOCALIZATION_JA,
       }),
     );
     const graphQLQueryObject: QueryRow = {};
@@ -81,7 +79,6 @@ describe("useGraphQLQuery", () => {
       useGraphQLQuery({
         columns,
         systemFilter: systemFilter,
-        localization: LOCALIZATION_JA,
       }),
     );
 
@@ -101,7 +98,6 @@ describe("useGraphQLQuery", () => {
       useGraphQLQuery({
         columns,
         systemFilter: undefined,
-        localization: LOCALIZATION_JA,
       }),
     );
 
@@ -116,7 +112,6 @@ describe("useGraphQLQuery", () => {
       useGraphQLQuery({
         columns,
         systemFilter: {},
-        localization: LOCALIZATION_JA,
       }),
     );
 

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useGraphQLQuery.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useGraphQLQuery.ts
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import dayjs from "dayjs";
 import { Column, MetaType } from "../types";
-import { Localization } from "..";
 import { FilterRowState, QueryRow } from "./types";
 import { FilterRowData } from "./useCustomFilter";
 

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useGraphQLQuery.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/useGraphQLQuery.ts
@@ -6,13 +6,12 @@ import { FilterRowState, QueryRow } from "./types";
 import { FilterRowData } from "./useCustomFilter";
 
 type UseGraphQLQueryProps<TData> = {
-  localization: Localization;
   systemFilter?: QueryRow;
   columns: Array<Column<TData>>;
 };
 
 export const useGraphQLQuery = <TData>(props: UseGraphQLQueryProps<TData>) => {
-  const { localization, systemFilter, columns } = props;
+  const { systemFilter, columns } = props;
 
   const valueConverter = useCallback(
     (
@@ -32,7 +31,7 @@ export const useGraphQLQuery = <TData>(props: UseGraphQLQueryProps<TData>) => {
 
       switch (metaType) {
         case "boolean":
-          return value.toLowerCase() === localization.filter.columnBoolean.true;
+          return value.toLowerCase() === "true";
         case "dateTime": {
           const date = dayjs(value);
           if (!date.isValid()) {
@@ -51,7 +50,7 @@ export const useGraphQLQuery = <TData>(props: UseGraphQLQueryProps<TData>) => {
           return value;
       }
     },
-    [localization.filter.columnBoolean.true],
+    [],
   );
 
   /**


### PR DESCRIPTION
# Background

https://tailorpartnershq.slack.com/archives/C0581HGGLH3/p1718103968781249

# Changes
-  in FilterRow, use localization only for UI label
- stop using localization in useGraphQLQuery
