### PR TITLE
chore(storybook): add type-check

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -9,6 +9,7 @@
     "build-storybook": "storybook build",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "type-check": "tsc --noEmit --incremental --pretty",
     "panda": "panda codegen",
     "ark:types": "node --loader ts-node/esm/transpile-only ./scripts/generate-ark-types.ts",
     "storybook:types": "node --loader ts-node/esm/transpile-only ./scripts/generate-storybook-types.ts",

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -18,6 +18,7 @@
   },
   "extends": "./node_modules/@tailor-platform/dev-config/typescript/design-systems.json",
   "include": ["src"],
+  "exclude": ["dist", "build", "node_modules"],
   "references": [
     {
       "path": "./tsconfig.node.json",


### PR DESCRIPTION
# Background

現状storybookのCIでtype-checkを実行していないため、型エラーがあっても無視された状態になっている。

# Changes

`type-check` をCIに組み込む
