### PR TITLE
chore(dev-config): bump up major version

### DIFF
--- a/packages/dev-config/package.json
+++ b/packages/dev-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tailor-platform/dev-config",
   "description": "Common package that hosts the rules for ESLint, Prettier and TypeScript.",
-  "version": "0.7.0",
+  "version": "1.0.0-alpha",
   "private": false,
   "scripts": {
     "build": "exit 0",


### PR DESCRIPTION
# Background

dev-config made breaking changes in #252, but forgot to bump the major version.

# Changes

Mark the version as `1.0.0-alpha`
