### PR TITLE
chore(ds): fix unnecessary testing assertions

### DIFF
--- a/packages/design-systems/src/components/Form.test.tsx
+++ b/packages/design-systems/src/components/Form.test.tsx
@@ -93,9 +93,7 @@ describe("TestForm", () => {
       render(<TestForm />);
       const user = userEvent.setup();
       await user.click(screen.getByRole("button", { name: "Submit" }));
-      await waitFor(() => {
-        expect(screen.getByText("Username is required.")).not.toBeNull();
-      });
+      expect(await screen.findByText("Username is required.")).not.toBeNull();
     });
   });
 });

--- a/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/HideShow.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/HideShow.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { useDataGrid } from "../useDataGrid";
@@ -117,10 +117,8 @@ describe("<HideShow />", () => {
     await user.click(screen.getByTestId("hide-show-Status"));
     await user.click(screen.getByTestId("datagrid-hide-show-button"));
 
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId("datagrid-header-status"),
-      ).not.toBeInTheDocument();
-    });
+    expect(
+      screen.queryByTestId("datagrid-header-status"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/PinnedColumn.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/ColumnFeature/PinnedColumn.test.tsx
@@ -149,8 +149,8 @@ describe("<PinnedColumn />", () => {
     expect(openPinnedColumnModal).toBeInTheDocument();
     await act(() => user.click(openPinnedColumnModal));
 
-    await waitFor(() => expect(screen.getByText("Pinned Right")).toBeVisible());
-    await waitFor(() => expect(screen.getByText("Pinned Left")).toBeVisible());
+    expect(await screen.findByText("Pinned Right")).toBeVisible();
+    expect(await screen.findByText("Pinned Left")).toBeVisible();
   });
 
   it("pinned the 'Status' column to right and pinned the 'Amount' column to left", async () => {

--- a/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
+++ b/packages/design-systems/src/components/composite/Datagrid/SearchFilter/CustomFilter.test.tsx
@@ -1121,11 +1121,8 @@ describe(
 
     it("When defaultFilter is not set, filterBadge is hidden", async () => {
       render(<DataGridWithFilter />);
-      const filterBadge = screen.getByTestId("filter-badge");
-      await waitFor(() => {
-        expect(filterBadge).toHaveStyle({
-          visibility: "hidden",
-        });
+      expect(await screen.findByTestId("filter-badge")).toHaveStyle({
+        visibility: "hidden",
       });
     });
 
@@ -1146,15 +1143,11 @@ describe(
       //Select value
       await selectValue(screen, user, 1, "pending");
 
-      await waitFor(() => {
-        expect(screen.getByTestId("filter-badge")).toHaveTextContent("2");
-      });
+      expect(await screen.findByTestId("filter-badge")).toHaveTextContent("2");
 
       // Reset filter
       await user.click(await screen.findByTestId("reset-filter-button"));
-      await waitFor(() => {
-        expect(screen.getByTestId("filter-badge")).toHaveTextContent("1");
-      });
+      expect(await screen.findByTestId("filter-badge")).toHaveTextContent("1");
     });
   },
 

--- a/packages/design-systems/src/components/composite/Datagrid/utils/test/customFilter.ts
+++ b/packages/design-systems/src/components/composite/Datagrid/utils/test/customFilter.ts
@@ -1,4 +1,4 @@
-import { within, Screen, waitFor } from "@testing-library/react";
+import { within, Screen } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event";
 
 /**
@@ -36,15 +36,14 @@ export const selectCondition = async (
 ) => {
   const selectCondition =
     screen.getAllByTestId("select-condition")[conditionIndex];
-  const selectConditionButton = within(selectCondition).getByRole("button");
-  await waitFor(() => user.click(selectConditionButton));
+  await user.click(await within(selectCondition).findByRole("button"));
   const selectConditionOptions = screen.getAllByTestId(
     "select-condition-options",
   )[conditionIndex];
   const eqConditionOption2 = within(selectConditionOptions).getByText(
     conditionName,
   );
-  await waitFor(() => user.click(eqConditionOption2));
+  await user.click(eqConditionOption2);
 };
 
 /**
@@ -72,7 +71,7 @@ export const selectJointCondition = async (
   const conditionOption = within(selectConditionOptions).getByText(
     jointConditionName,
   );
-  await waitFor(() => user.click(conditionOption));
+  await user.click(conditionOption);
 };
 
 /**
@@ -92,8 +91,7 @@ export const selectValue = async (
   const selectValue = screen.getAllByTestId("select-input-value")[valueIndex];
   const selectValueButton = within(selectValue).getByRole("button");
   await user.click(selectValueButton);
-  const successOption = screen.getByRole("option", { name: value });
-  await waitFor(() => user.click(successOption));
+  await user.click(await screen.findByRole("option", { name: value }));
 };
 
 /**


### PR DESCRIPTION
# Background

テストコードで正しくない要素の取得を行なっている箇所が散見される

# Changes

* waitFor + get の組み合わせは find を使うべきなので修正した
* `user.click` を waitFor で囲う必要はないので、除去
