### PR TITLE
Chore: update node version used in actions.

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version-file: 'package.json'
 

--- a/.github/actions/install_and_build/action.yml
+++ b/.github/actions/install_and_build/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version-file: 'package.json'
 

--- a/.github/workflows/check_existing_release.yml
+++ b/.github/workflows/check_existing_release.yml
@@ -26,7 +26,7 @@ jobs:
       tag: "${{ inputs.package_name }}/${{ steps.extract-version.outputs.version }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Read JSON file
         id: read-json
         run: | # read JSON file without having to handle escaping newlines etc.

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,7 +13,7 @@ jobs:
   publish-to-chromatic:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: true
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,10 +13,8 @@ jobs:
       pull-requests: write
     steps:
       - name: Add labels
-        uses: release-drafter/release-drafter@65c5fb495d1e69aa8c08a3317bc44ff8aabe9772 # v5.24.0
+        uses: release-drafter/release-drafter@v6
         with:
-          # Auto labeler will be made a separate action, for now use release-drafter only for its auto labeler.
-          # See https://github.com/release-drafter/release-drafter/issues/1216#issuecomment-1235291851
           disable-releaser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make_github_release.yml
+++ b/.github/workflows/make_github_release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get previous tag
         id: get-previous-tag
         run: |

--- a/.github/workflows/publish_npm_package.yml
+++ b/.github/workflows/publish_npm_package.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
 

--- a/.github/workflows/publish_npm_package.yml
+++ b/.github/workflows/publish_npm_package.yml
@@ -16,7 +16,7 @@ jobs:
   publish-npm-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test_package_auth.yml
+++ b/.github/workflows/test_package_auth.yml
@@ -11,7 +11,7 @@ jobs:
   test-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/ci
         with:
           package: "@tailor-platform/auth"

--- a/.github/workflows/test_package_dev-cli.yml
+++ b/.github/workflows/test_package_dev-cli.yml
@@ -11,7 +11,7 @@ jobs:
   test-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/ci
         with:
           package: "@tailor-platform/dev-cli"

--- a/.github/workflows/test_package_ds.yml
+++ b/.github/workflows/test_package_ds.yml
@@ -11,7 +11,7 @@ jobs:
   test-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/ci
         with:
           package: "@tailor-platform/design-systems"

--- a/.github/workflows/test_package_monitoring.yml
+++ b/.github/workflows/test_package_monitoring.yml
@@ -11,7 +11,7 @@ jobs:
   test-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/ci
         with:
           package: "@tailor-platform/monitoring"

--- a/.github/workflows/test_package_utils.yml
+++ b/.github/workflows/test_package_utils.yml
@@ -11,7 +11,7 @@ jobs:
   test-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/ci
         with:
           package: "@tailor-platform/utils"


### PR DESCRIPTION
# Background

<!-- Why is this change necessary, how it came to be? -->

We use `actions/checkout@v3` and `actions/setup-node@v3`.
These internally use Node.js 16 that are deprecated.

ref. https://github.com/tailor-platform/frontend-packages/actions/runs/9610259380
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3. 
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
Replace:
- `actions/checkout@v3` -> `actions/checkout@v4`
- `actions/setup-node@v3` -> `actions/setup-node@v4`