### PR TITLE
fix: fix release_package_manually.yml trigger to workflow_dispatch

### DIFF
--- a/.github/workflows/release_package_manually.yml
+++ b/.github/workflows/release_package_manually.yml
@@ -1,7 +1,7 @@
 name: release package manually
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       package:
         type: string


### PR DESCRIPTION
# Background

<!-- Why is this change necessary, how it came to be? -->
If we want to run action manually, we should set "workflow_dispatch" trigger.
https://docs.github.com/actions/using-workflows/manually-running-a-workflow

# Changes

<!-- The "what": Describe what this PR adds or changes to help reviewers grasp what it's about. -->
- change `.github/workflows/release_package_manually.yml` trigger: `workflow_call` -> `workflow_dispatch`