### PR TITLE
fix: run action only on push tag in main branch

### DIFF
--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -2,7 +2,6 @@ name: release package
 
 on:
   push:
-    branches: main
     tags: "*/*"
 
 permissions:
@@ -26,6 +25,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Check branch is main
+        run: |
+          echo "$(git branch --show-current)"
+          test "$(git branch --show-current)" = "main"
       - name: Check version matches package.json version
         working-directory: packages/${{ steps.extract.outputs.package }}
         run: |


### PR DESCRIPTION
# Background

<!-- Why is this change necessary, how did it come about? --> 
Release action is expected to be triggered by a tag push in the main branch.

# Changes

<!-- The "what": Describe what this PR adds or changes, to help reviewers understand what it's about. -->
- remove trigger `on.push.branches: main`
- check branch in first job