### PR TITLE
chore(storybook): add pull-requests write permission

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,6 +9,9 @@ on:
       - .github/workflows/chromatic.yml
       - .github/actions/ci/action.yml
 
+permissions:
+  pull-requests: write
+
 jobs:
   publish-to-chromatic:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Background

stick-pull-request-comment action needs `pull-requests: write` permission, but ours does not have that.

# Changes

Add it.